### PR TITLE
Update Answers links and Changelog capitalization in Community index.md

### DIFF
--- a/src/docs/Community/index.md
+++ b/src/docs/Community/index.md
@@ -13,18 +13,18 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
 
 Stay up to date on Laserfiche Cloud and connected to the broader Laserfiche community.
 
-Visit the [Laserfiche Answers](https://answers.laserfiche.com/questions/topic/53/Laserfiche-Cloud) forum to connect with our staff and other developers in the community.
+Visit the [Laserfiche Answers](https://answers.laserfiche.com/) forum to connect with our staff and other developers in the community.
 
 - Stuck on a coding question? Get helpful feedback on your code from the community.
 - Have feature requests and feedback? We love hearing about what you’re building and how we can improve the API!
 
 Tip: Be sure to tag your post under the [Laserfiche API](https://answers.laserfiche.com/questions/topic/67/Laserfiche-API) topic to get others’ attention!
 
-For the latest Laserfiche Cloud updates, visit the [Cloud changelog](https://doc.laserfiche.com/laserfiche.documentation/en-us/Default.htm#changelog.htm).
+For the latest Laserfiche Cloud updates, visit the [Cloud Changelog](https://doc.laserfiche.com/laserfiche.documentation/en-us/Default.htm#changelog.htm).
 
 For the latest Repository API changes, visit:
 
 - [API Version 1 - Changelog](https://api.laserfiche.com/repository/v1/changelog)
-- [API Version 2 - changelog](https://api.laserfiche.com/repository/v2/changelog)
+- [API Version 2 - Changelog](https://api.laserfiche.com/repository/v2/changelog)
 
 Experiencing a problem with the API or your account? Reach out to your Solution Provider to open a support case with us.


### PR DESCRIPTION
1. Changed Laserfiche Answers link to the homepage instead of the Laserfiche Cloud topic URI.
2. Fixed inconsistent capitalization for "Changelog". Now has initial caps everywhere on the page.