### PR TITLE
fix formatting mistakes

### DIFF
--- a/src/docs/api/authentication/guide_oauth-spa/index.md
+++ b/src/docs/api/authentication/guide_oauth-spa/index.md
@@ -29,7 +29,7 @@ A single-page app (SPA) is a web application that runs entirely in the browser. 
 
 ## Generating a PKCE Code Verifier and Code Challenge
 
-1. SPAs run entirely in the browser and do not have the ability to store server-side secrets. They can be susceptible to authorization code interception attacks when using the authorization code flow, which is why we require SPAs to also use the PKCE extension with the regular authorization code flow. To use the PKCE extension, _code_verifier_ and _code_challenge_ values need to be generated as specified in [RFC 7636 section 4.1](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1). See the following C# sample code for generating the _code_verifier_ and _code_challenge_.
+SPAs run entirely in the browser and do not have the ability to store server-side secrets. They can be susceptible to authorization code interception attacks when using the authorization code flow, which is why we require SPAs to also use the PKCE extension with the regular authorization code flow. To use the PKCE extension, _code_verifier_ and _code_challenge_ values need to be generated as specified in [RFC 7636 section 4.1](https://datatracker.ietf.org/doc/html/rfc7636#section-4.1). See the following C# sample code for generating the _code_verifier_ and _code_challenge_.
 
    - ```js
        var rng = RandomNumberGenerator.Create();

--- a/src/docs/api/authentication/guide_service-principals/index.md
+++ b/src/docs/api/authentication/guide_service-principals/index.md
@@ -55,8 +55,8 @@ A Service Principal will always have two keys at any given time. Either of the k
 
 1. To regenerate a new key, click the "Rotate" action for the desired key that you want to rotate. ![](./assets/images/service-principals-04.png)
 
-{: .note }
-Note: Two keys are given to a Service Principal in order to seamlessly rotate a Principal’s credentials without any down time. For instance, let’s say your Service Principal is powering an integration in the production environment using Key #1. In order to follow security best practices, you’d like to rotate the password of the Principal. You may replace the Principal’s credentials in your integration code with Key #2. You can then go back and disable Key #1. The next time you want to rotate the Principal’s key, you can regenerate a new key for Key #1 using the Rotate action.
+    {: .note }
+    Note: Two keys are given to a Service Principal in order to seamlessly rotate a Principal’s credentials without any down time. For instance, let’s say your Service Principal is powering an integration in the production environment using Key #1. In order to follow security best practices, you’d like to rotate the password of the Principal. You may replace the Principal’s credentials in your integration code with Key #2. You can then go back and disable Key #1. The next time you want to rotate the Principal’s key, you can regenerate a new key for Key #1 using the Rotate action.
 
 1.  By default, Service Principal keys will expire after 90 days. You can change this behavior under the Settings tab of Account Administration, on the Integration Configuration subsection ![](./assets/images/service-principals-05.png)
 

--- a/src/docs/getting-started/guide_low-code-tools-v1/index.md
+++ b/src/docs/getting-started/guide_low-code-tools-v1/index.md
@@ -112,8 +112,10 @@ See the [importing a document guide](../../guides/documents-and-folders/guide_im
    - The Access Token from the **Get Laserfiche Access Token** [action](#authentication) must be added to the Authorization header. Format the Authorization header value as follows `Bearer @{body('Get_Laserfiche_Access_Token')['access_token']}`.
    - The request **body** is a multipart/form-data with two parts.
      - The first part contains the file content from the **Get file content using path** action.
-     {: .note }
-     **Note:** The `Content-Type` header or the extension in the filename in the `Content-Disposition` header is used to determine the file type for the document imported to Laserfiche.
+     
+        {: .note }
+        **Note:** The `Content-Type` header or the extension in the filename in the `Content-Disposition` header is used to determine the file type for the document imported to Laserfiche.
+        
      - As an example, the second part assigns the `Email` template and the `Sender` and `Recipients` fields to the imported file. The metadata may need to be updated if the template and field definitions do not exist in the Laserfiche repository.
 
 1. Copy and paste the following request body.

--- a/src/docs/getting-started/guide_low-code-tools/index.md
+++ b/src/docs/getting-started/guide_low-code-tools/index.md
@@ -32,30 +32,30 @@ The Laserfiche Cloud APIs follows the [OAuth 2.0 authorization model](../../api/
 
 1. Create an HTTP action in your low-code solution to obtain an Access Token given a long-lasting `{authorizationKey}`obtained during the application registration.
 
-```
-POST https://signin.laserfiche.com/oauth/token
-Authorization: Bearer {authorizationKey}
-Content-Type: application/x-www-form-urlencoded
-grant_type=client_credentials&scope=repository.ReadWrite
-```
+    ```
+    POST https://signin.laserfiche.com/oauth/token
+    Authorization: Bearer {authorizationKey}
+    Content-Type: application/x-www-form-urlencoded
+    grant_type=client_credentials&scope=repository.ReadWrite
+    ```
 
-- The hostname in the request URI may need to be updated to `signin.laserfiche.ca`, `signin.eu.laserfiche.com`, etc., depending on the data center your Laserfiche Cloud repository resides in.
-  For example in Microsoft Power Automate, the **Get Laserfiche Access Token** action will look like:
-  ![](./assets/images/low-code-authenticate-cloud.png)
+1. The hostname in the request URI may need to be updated to `signin.laserfiche.ca`, `signin.eu.laserfiche.com`, etc., depending on the data center your Laserfiche Cloud repository resides in. For example in Microsoft Power Automate, the **Get Laserfiche Access Token** action will look like:
+
+    ![](./assets/images/low-code-authenticate-cloud.png)
 
 1. A successful response will contain the Access Token needed to make Laserfiche API requests.
 
-```
-HTTP 200 OK
-```
-```json
-{
-  "access_token": "...",
-  "token_type": "bearer",
-  "expires_in": 43200,
-  "scope": "repository.Read repository.Write"
-}
-```
+    ```
+    HTTP 200 OK
+    ```
+    ```json
+    {
+      "access_token": "...",
+      "token_type": "bearer",
+      "expires_in": 43200,
+      "scope": "repository.Read repository.Write"
+    }
+    ```
 
 1. The Access Token obtained from the **Get Laserfiche Access Token** action can then be used by downstream HTTP actions that interact with the Laserfiche APIs. For example, [import a document using a low-code tool](#use-case-importing-a-document-from-microsoft-onedrive-into-laserfiche-using-microsoft-power-automate).
 
@@ -70,24 +70,26 @@ See the [this guide](../../guides/documents-and-folders/guide_importing-document
 
 1. In Microsoft Power Automate, create a OneDrive **Get file metadata** action and select a document to import into Laserfiche.
 1. Link a OneDrive **Get file content using path** action and set the file path to the **Path** from the **Get file metadata** action.
+
    ![](./assets/images/low-code-get-document.png)
 1. Link an HTTP action to import the document into Laserfiche and assign a template and two fields. ![](./assets/images/low-code-import-document-v2.png)
 
-- The request **URI** is `https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{parentFolderId}/Folder/Import`. The hostname may need to be updated to `api.laserfiche.ca`, `api.eu.laserfiche.com`, etc., depending on the data center your Laserfiche Cloud repository resides in, where:
-  - `{repositoryId}` is your Laserfiche repository ID.
-  - `{parentFolderId}` is the Laserfiche entry ID of the folder the document will be imported to.
-  - `{documentName}` is the name of the document when imported to the Laserfiche repository.
-- The Access Token from the **Get Laserfiche Access Token** [action](#authentication) must be added to the Authorization header.
-  Format the Authorization header value as follows `Bearer @{body('Get_Laserfiche_Access_Token')['access_token']}`.
-- The request **body** is a multipart/form-data with two parts.
+    - The request **URI** is `https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{parentFolderId}/Folder/Import`. The hostname may need to be updated to `api.laserfiche.ca`, `api.eu.laserfiche.com`, etc., depending on the data center your Laserfiche Cloud repository resides in, where:
+      - `{repositoryId}` is your Laserfiche repository ID.
+      - `{parentFolderId}` is the Laserfiche entry ID of the folder the document will be imported to.
+      - `{documentName}` is the name of the document when imported to the Laserfiche repository.
+    - The Access Token from the **Get Laserfiche Access Token** [action](#authentication) must be added to the Authorization header.
+      Format the Authorization header value as follows `Bearer @{body('Get_Laserfiche_Access_Token')['access_token']}`.
+    - The request **body** is a multipart/form-data with two parts.
 
-  - The first part contains the file content from the **Get file content using path** action.
+      - The first part contains the file content from the **Get file content using path** action.
 
-    {: .note }
-    **Note:** The `Content-Type` header or the extension in the filename in the `Content-Disposition` header is used to determine the file type for the document imported to Laserfiche.
+        {: .note }
+        **Note:** The `Content-Type` header or the extension in the filename in the `Content-Disposition` header is used to determine the file type for the document imported to Laserfiche.
 
-    - As an example, the second part assigns the `Email` template and the `Sender` and `Recipients` fields to the imported file. The metadata may need to be updated if the template and field definitions do not exist in the Laserfiche repository. - `{documentName}` is the name of the document when imported to the Laserfiche repository. - `autoRename` indicates if the imported entry should be automatically renamed if an entry already exists with the given name in the folder. The default value is false.
-      Copy and paste the following request body.
+        - As an example, the second part assigns the `Email` template and the `Sender` and `Recipients` fields to the imported file. The metadata may need to be updated if the template and field definitions do not exist in the Laserfiche repository. - `{documentName}` is the name of the document when imported to the Laserfiche repository. - `autoRename` indicates if the imported entry should be automatically renamed if an entry already exists with the given name in the folder. The default value is false.
+
+1. Copy and paste the following request body.
 
   ```json
   {

--- a/src/docs/guides/metadata/guide_write-field-values/index.md
+++ b/src/docs/guides/metadata/guide_write-field-values/index.md
@@ -64,7 +64,6 @@ PUT https://api.laserfiche.com/repository/v2/Repositories/r-abc123/Entries/12345
 
 {: .note}
 
-- **Note:**
 - If there are other fields with existing values assigned to the entry, your request body must include the existing values or else the update will clear out values not included in the request.
 - For the **Date**, the value should not contain any time zone information. Datetime values are stored as-is in the repository. If the value contains any time zone offset information like "Z" or "+08:00", the request will be rejected.
 


### PR DESCRIPTION
The common theme to these mistakes is that they screw up ordered lists that should be of the for 1, 2, 3, 4,..., but are actually of the form 1, 2, 3, 1, 2,...