### PR TITLE
Feature: Add a light/dark mode theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Site files
 **_site
+**_build
 
 # Logs
 logs

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,8 +28,7 @@
         "jekyll",
         "build",
         "--destination",
-        "../_site",
-        "--incremental",
+        "../_build",
         "--baseurl=${input:BaseURL}"
       ],
       "options": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "serve",
+      "type": "shell",
+      "args": [
+        "exec",
+        "jekyll",
+        "serve",
+        "--destination",
+        "../_site",
+        "--incremental"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/"
+      },
+      "problemMatcher": [],
+      "command": "bundle"
+    },
+    {
+      "label": "build",
+      "type": "shell",
+      "args": [
+        "exec",
+        "jekyll",
+        "serve",
+        "--destination",
+        "../_site",
+        "--incremental",
+        "--baseurl=${input:BaseURL}"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/"
+      },
+      "problemMatcher": [],
+      "command": "bundle"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "BaseURL",
+      "description": "Default /developer",
+      "default": "/developer",
+      "type": "promptString"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       "args": [
         "exec",
         "jekyll",
-        "serve",
+        "build",
         "--destination",
         "../_site",
         "--incremental",

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -26,8 +26,8 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
     </svg>
   </symbol>
 </svg>
-<a class="btn" id="theme-toggle">
-  <svg width="18px" height="18px">
+<button class="site-button btn-reset" id="theme-toggle">
+  <svg class="icon" viewBox="0 0 24 24">
     <use href="#svg-sun"></use>
   </svg>
-</a>
+</button>

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -1,2 +1,33 @@
 <!--© 2024 Laserfiche.
 See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="svg-sun" viewBox="0 0 24 24">
+    <title>Light mode</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="feather-sun">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+  </symbol>
+  <symbol id="svg-moon" viewBox="0 0 24 24">
+    <title>Dark mode</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-tabler-moon">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
+    </svg>
+  </symbol>
+</svg>
+<a class="btn" id="theme-toggle">
+  <svg width="18px" height="18px">
+    <use href="#svg-sun"></use>
+  </svg>
+</a>

--- a/src/_includes/js/custom.js
+++ b/src/_includes/js/custom.js
@@ -1,3 +1,55 @@
 // © 2024 Laserfiche.
 // See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.
 
+(() => {
+  const setThemeIcon = (theme) => {
+    const toggleDarkMode = document.getElementById('theme-toggle');
+    const svg = toggleDarkMode.querySelector('use');
+    if (theme === 'dark') {
+      svg.setAttribute('href', '#svg-sun');
+    } else {
+      svg.setAttribute('href', '#svg-moon');
+    }
+  }
+  if (localStorage.getItem('color-scheme') === null) {
+    const newColorScheme =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+    document.hidden;
+    jtd.setTheme(newColorScheme);
+    localStorage.setItem('color-scheme', newColorScheme);
+
+    window.addEventListener('DOMContentLoaded', function () {
+      setThemeIcon(newColorScheme);
+    });
+  } else {
+    jtd.setTheme(localStorage.getItem('color-scheme'));
+    window.addEventListener('DOMContentLoaded', function () {
+      setThemeIcon(localStorage.getItem('color-scheme'));
+    });
+  }
+
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (event) => {
+      if (localStorage.getItem('color-scheme') === null) {
+        const newColorScheme = event.matches ? 'dark' : 'light';
+        jtd.setTheme(newColorScheme);
+        setThemeIcon(newColorScheme);
+        localStorage.setItem('color-scheme', newColorScheme);
+      }
+    });
+
+  window.addEventListener('DOMContentLoaded', function () {
+    const toggleDarkMode = document.getElementById('theme-toggle');
+    jtd.addEvent(toggleDarkMode, 'click', function () {
+      const newColorScheme = jtd.getTheme() !== 'dark' ? 'dark' : 'light';
+      jtd.setTheme(newColorScheme);
+      setThemeIcon(newColorScheme);
+      localStorage.setItem('color-scheme', newColorScheme);
+    });
+  });
+})(window.jtd);

--- a/src/_sass/color_schemes/dark.scss
+++ b/src/_sass/color_schemes/dark.scss
@@ -2,7 +2,7 @@ $color-scheme: dark;
 $body-background-color: $grey-dk-300;
 $body-heading-color: $grey-lt-000;
 $body-text-color: $grey-lt-300;
-$link-color: $lf-link;
+$link-color: lighten($lf-link, 25%);
 $nav-child-link-color: $grey-dk-000;
 $sidebar-color: $grey-dk-300;
 $base-button-color: $grey-dk-250;
@@ -14,5 +14,7 @@ $table-background-color: $grey-dk-250;
 $search-background-color: $grey-dk-250;
 $search-result-preview-color: $grey-dk-000;
 $border-color: $grey-dk-200;
+$note-bg-color: #4b3d18;
+$lf-orange: lighten($lf-orange, 10%);
 
 @import "./vendor/OneDarkJekyll/syntax"; // this is the one-dark-vivid atom syntax theme

--- a/src/_sass/color_schemes/light.scss
+++ b/src/_sass/color_schemes/light.scss
@@ -12,5 +12,6 @@ $feedback-color: darken($sidebar-color, 3%) !default;
 $table-background-color: $white !default;
 $search-background-color: $white !default;
 $search-result-preview-color: $grey-dk-000 !default;
+$note-bg-color: #FFEEC1;
 
 @import "./vendor/OneLightJekyll/syntax";

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -135,17 +135,20 @@
     background-color: $note-bg-color;
   }
 }
-#theme-toggle {
-  width: $sp-8;
-  height: $sp-8;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  align-self: center;
-  margin-right: $sp-1;
-}
-// @media (min-width: $value) {
-//   #theme-toggle {
-//     width: ;
-//   }
+// #theme-toggle {
+//   // width: $sp-8;
+//   // height: $sp-8;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   align-self: center;
+//   margin-right: $sp-2;
+
 // }
+
+#theme-toggle {
+  margin-left: auto;
+  @include mq(lg) {
+    margin-left: unset;
+  }
+}

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -1,6 +1,6 @@
 #footer {
   min-height: $min-footer-height;
-  background-color: rgb(252, 252, 252);
+  background-color: $body-background-color;
   a:not([class]) {
     text-decoration: none;
   }
@@ -10,7 +10,7 @@
     padding-inline-start: 0px;
     margin: 12px;
     margin-left: 0px;
-    
+
     li {
       &::before {
         content: none;
@@ -56,7 +56,7 @@
       font-weight: bold;
       color: $lf-orange;
       margin: 10px;
-      margin-right:0px;
+      margin-right: 0px;
     }
 
     .Resources,
@@ -75,14 +75,14 @@
         }
         .sub-menu {
           div {
-            color: #222c33;
+            color: $body-text-color;
             font-weight: normal;
           }
         }
         #ot-sdk-btn {
           border: none !important;
           background: transparent;
-          color: #222c33;
+          color: $body-text-color;
           display: inline-block;
           font-size: 1rem;
           font-weight: 400;
@@ -129,3 +129,23 @@
   position: absolute;
   width: 1px;
 }
+
+.main-content {
+  .note {
+    background-color: $note-bg-color;
+  }
+}
+#theme-toggle {
+  width: $sp-8;
+  height: $sp-8;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+  margin-right: $sp-1;
+}
+// @media (min-width: $value) {
+//   #theme-toggle {
+//     width: ;
+//   }
+// }

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -135,16 +135,6 @@
     background-color: $note-bg-color;
   }
 }
-// #theme-toggle {
-//   // width: $sp-8;
-//   // height: $sp-8;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   align-self: center;
-//   margin-right: $sp-2;
-
-// }
 
 #theme-toggle {
   margin-left: auto;


### PR DESCRIPTION
Notes: 
- Attempted to maintain best practice in adding the toggle to jtd custom docs only
- new header_custom only allowed placing the icon within the menu bar on < large screen sizes. Would have preferred to put it to the left of the menu icon in those screen sizes, but opted for only editing custom marked files
- Dark mode does not directly conform to any LF color scheme. I opted for the closest color of blue that met WCAG contrast guidelines against the default dark mode background color. Orange worked out just fine on both.
- Update the custom CSS for the page footer to use the default SASS variables for text color so they would update appropriately when themes are toggled using ootb jtd theme.