### PR TITLE
New Feature: Add dark theme toggle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Site files
 **_site
+**_build
 
 # Logs
 logs

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ lib
 release
 solution
 temp
+.jekyll-metadata
 
 # Coverage directory used by tools like istanbul
 coverage

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -28,8 +28,7 @@
         "jekyll",
         "build",
         "--destination",
-        "../_site",
-        "--incremental",
+        "../_build",
         "--baseurl=${input:BaseURL}"
       ],
       "options": {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=733558
+  // for the documentation about the tasks.json format
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "serve",
+      "type": "shell",
+      "args": [
+        "exec",
+        "jekyll",
+        "serve",
+        "--destination",
+        "../_site",
+        "--incremental"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/"
+      },
+      "problemMatcher": [],
+      "command": "bundle"
+    },
+    {
+      "label": "build",
+      "type": "shell",
+      "args": [
+        "exec",
+        "jekyll",
+        "serve",
+        "--destination",
+        "../_site",
+        "--incremental",
+        "--baseurl=${input:BaseURL}"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/"
+      },
+      "problemMatcher": [],
+      "command": "bundle"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "BaseURL",
+      "description": "Default /developer",
+      "default": "/developer",
+      "type": "promptString"
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
       "args": [
         "exec",
         "jekyll",
-        "serve",
+        "build",
         "--destination",
         "../_site",
         "--incremental",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -36,6 +36,19 @@
       },
       "problemMatcher": [],
       "command": "bundle"
+    },
+    {
+      "label": "bundle exec rake",
+      "type": "shell",
+      "args": [
+        "exec",
+        "rake"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/src/"
+      },
+      "problemMatcher": [],
+      "command": "bundle"
     }
   ],
   "inputs": [

--- a/src/_includes/head.html
+++ b/src/_includes/head.html
@@ -9,24 +9,18 @@ on page. {%- endcomment -%}
   <meta charset="UTF-8" />
   <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
 
-  <link
-    rel="stylesheet"
-    href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}"
-  />
+  <link rel="stylesheet" href="{{ '/assets/css/just-the-docs-default.css' | relative_url }}" />
 
   {% include head_nav.html %} {% if site.ga_tracking != nil %} {% assign
   ga_tracking_ids = site.ga_tracking | split: "," %}
-  <script
-    async
-    src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"
-  ></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_tracking_ids.first }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
 
     {% for ga_property in ga_tracking_ids %}
-      gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
+    gtag('config', '{{ ga_property }}'{% unless site.ga_tracking_anonymize_ip == nil %}, { 'anonymize_ip': true }{% endunless %});
     {% endfor %}
   </script>
   {% endif %} {% if site.search_enabled != false %}

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -26,8 +26,8 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
     </svg>
   </symbol>
 </svg>
-<a class="btn" id="theme-toggle">
-  <svg width="18px" height="18px">
+<button class="site-button btn-reset" id="theme-toggle">
+  <svg class="icon" viewBox="0 0 24 24">
     <use href="#svg-sun"></use>
   </svg>
-</a>
+</button>

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -1,2 +1,33 @@
 <!--© 2024 Laserfiche.
 See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+  <symbol id="svg-sun" viewBox="0 0 24 24">
+    <title>Light mode</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="feather-sun">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+  </symbol>
+  <symbol id="svg-moon" viewBox="0 0 24 24">
+    <title>Dark mode</title>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-tabler-moon">
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
+    </svg>
+  </symbol>
+</svg>
+<a class="btn" id="theme-toggle">
+  <svg width="18px" height="18px">
+    <use href="#svg-sun"></use>
+  </svg>
+</a>

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -4,8 +4,8 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <symbol id="svg-sun" viewBox="0 0 24 24">
     <title>Light mode</title>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="feather-sun">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
+      stroke-linecap="round" stroke-linejoin="round" class="feather-sun">
       <circle cx="12" cy="12" r="5"></circle>
       <line x1="12" y1="1" x2="12" y2="3"></line>
       <line x1="12" y1="21" x2="12" y2="23"></line>
@@ -19,10 +19,17 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
   </symbol>
   <symbol id="svg-moon" viewBox="0 0 24 24">
     <title>Dark mode</title>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor"
-      stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" class="icon-tabler-moon">
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
+      stroke-linecap="round" stroke-linejoin="round" class="icon-tabler-moon">
       <path stroke="none" d="M0 0h24v24H0z" fill="none" />
       <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
+    </svg>
+  </symbol>
+  <symbol id="svg-edit">
+    <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
+      stroke-linejoin="round">
+      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
     </svg>
   </symbol>
 </svg>
@@ -31,3 +38,10 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
     <use href="#svg-sun"></use>
   </svg>
 </button>
+<a>
+  <button class="site-button btn-reset" id="edit-button" title="Edit this document">
+    <svg class="icon" viewBox="0 0 24 24">
+      <use href="#svg-edit"></use>
+    </svg>
+  </button>
+</a>

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -31,19 +31,21 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
     </svg>
   </symbol>
 </svg>
-<button class="site-button btn-reset" id="theme-toggle">
-  <svg class="icon" viewBox="0 0 24 24">
-    <use href="#svg-sun"></use>
-  </svg>
-</button>
-<a href="https://github.com/Laserfiche/laserfiche.github.io/blob/1.x/src/{{page.path}}" class="site-button btn-reset"
-  id="edit-button" title="Edit this document">
-  <svg class="icon" viewBox="0 0 24 24">
-    <use href="#svg-edit"></use>
-  </svg>
-</a>
-<a href="https://answers.laserfiche.com/" class="site-button btn-reset" id="feedback-button" title="Feedback">
-  <svg class="icon" viewBox="0 0 24 24">
-    <use href="#svg-feedback"></use>
-  </svg>
-</a>
+<div class="site-button btn-reset">
+  <button class="site-button btn-reset" id="theme-toggle">
+    <svg class="icon" viewBox="0 0 24 24">
+      <use href="#svg-sun"></use>
+    </svg>
+  </button>
+  <a href="https://github.com/Laserfiche/laserfiche.github.io/blob/1.x/src/{{page.path}}" class="site-button btn-reset"
+    id="edit-button" title="Edit this document">
+    <svg class="icon" viewBox="0 0 24 24">
+      <use href="#svg-edit"></use>
+    </svg>
+  </a>
+  <a href="https://answers.laserfiche.com/" class="site-button btn-reset" id="feedback-button" title="Feedback">
+    <svg class="icon" viewBox="0 0 24 24">
+      <use href="#svg-feedback"></use>
+    </svg>
+  </a>
+</div>

--- a/src/_includes/header_custom.html
+++ b/src/_includes/header_custom.html
@@ -3,33 +3,31 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
 
 <svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <symbol id="svg-sun" viewBox="0 0 24 24">
-    <title>Light mode</title>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
-      stroke-linecap="round" stroke-linejoin="round" class="feather-sun">
-      <circle cx="12" cy="12" r="5"></circle>
-      <line x1="12" y1="1" x2="12" y2="3"></line>
-      <line x1="12" y1="21" x2="12" y2="23"></line>
-      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
-      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
-      <line x1="1" y1="12" x2="3" y2="12"></line>
-      <line x1="21" y1="12" x2="23" y2="12"></line>
-      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
-      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"
+      stroke="currentColor">
+      <path
+        d="M440-760v-160h80v160h-80Zm266 110-55-55 112-115 56 57-113 113Zm54 210v-80h160v80H760ZM440-40v-160h80v160h-80ZM254-652 140-763l57-56 113 113-56 54Zm508 512L651-255l54-54 114 110-57 59ZM40-440v-80h160v80H40Zm157 300-56-57 112-112 29 27 29 28-114 114Zm283-100q-100 0-170-70t-70-170q0-100 70-170t170-70q100 0 170 70t70 170q0 100-70 170t-170 70Zm0-80q66 0 113-47t47-113q0-66-47-113t-113-47q-66 0-113 47t-47 113q0 66 47 113t113 47Zm0-160Z" />
     </svg>
   </symbol>
   <symbol id="svg-moon" viewBox="0 0 24 24">
-    <title>Dark mode</title>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"
-      stroke-linecap="round" stroke-linejoin="round" class="icon-tabler-moon">
-      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
-      <path d="M12 3c.132 0 .263 0 .393 0a7.5 7.5 0 0 0 7.92 12.446a9 9 0 1 1 -8.313 -12.454z" />
+    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"
+      stroke="currentColor">
+      <path
+        d="M484-80q-84 0-157.5-32t-128-86.5Q144-253 112-326.5T80-484q0-146 93-257.5T410-880q-18 99 11 193.5T521-521q71 71 165.5 100T880-410q-26 144-138 237T484-80Zm0-80q88 0 163-44t118-121q-86-8-163-43.5T464-465q-61-61-97-138t-43-163q-77 43-120.5 118.5T160-484q0 135 94.5 229.5T484-160Zm-20-305Z" />
     </svg>
   </symbol>
-  <symbol id="svg-edit">
-    <svg xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"
-      stroke-linejoin="round">
-      <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
-      <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  <symbol id="svg-edit" viewBox="0 0 24 24">
+    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"
+      stroke="currentColor">
+      <path
+        d="M560-80v-123l221-220q9-9 20-13t22-4q12 0 23 4.5t20 13.5l37 37q8 9 12.5 20t4.5 22q0 11-4 22.5T903-300L683-80H560Zm300-263-37-37 37 37ZM620-140h38l121-122-18-19-19-18-122 121v38ZM240-80q-33 0-56.5-23.5T160-160v-640q0-33 23.5-56.5T240-880h320l240 240v120h-80v-80H520v-200H240v640h240v80H240Zm280-400Zm241 199-19-18 37 37-18-19Z" />
+    </svg>
+  </symbol>
+  <symbol id="svg-feedback">
+    <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor"
+      stroke="currentColor">
+      <path
+        d="M240-400h320v-80H240v80Zm0-120h480v-80H240v80Zm0-120h480v-80H240v80ZM80-80v-720q0-33 23.5-56.5T160-880h640q33 0 56.5 23.5T880-800v480q0 33-23.5 56.5T800-240H240L80-80Zm126-240h594v-480H160v525l46-45Zm-46 0v-480 480Z" />
     </svg>
   </symbol>
 </svg>
@@ -38,10 +36,14 @@ See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license infor
     <use href="#svg-sun"></use>
   </svg>
 </button>
-<a>
-  <button class="site-button btn-reset" id="edit-button" title="Edit this document">
-    <svg class="icon" viewBox="0 0 24 24">
-      <use href="#svg-edit"></use>
-    </svg>
-  </button>
+<a href="https://github.com/Laserfiche/laserfiche.github.io/blob/1.x/src/{{page.path}}" class="site-button btn-reset"
+  id="edit-button" title="Edit this document">
+  <svg class="icon" viewBox="0 0 24 24">
+    <use href="#svg-edit"></use>
+  </svg>
+</a>
+<a href="https://answers.laserfiche.com/" class="site-button btn-reset" id="feedback-button" title="Feedback">
+  <svg class="icon" viewBox="0 0 24 24">
+    <use href="#svg-feedback"></use>
+  </svg>
 </a>

--- a/src/_includes/js/custom.js
+++ b/src/_includes/js/custom.js
@@ -1,3 +1,55 @@
 // © 2024 Laserfiche.
 // See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.
 
+(() => {
+  const setThemeIcon = (theme) => {
+    const toggleDarkMode = document.getElementById('theme-toggle');
+    const svg = toggleDarkMode.querySelector('use');
+    if (theme === 'dark') {
+      svg.setAttribute('href', '#svg-sun');
+    } else {
+      svg.setAttribute('href', '#svg-moon');
+    }
+  }
+  if (localStorage.getItem('color-scheme') === null) {
+    const newColorScheme =
+      window.matchMedia &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+
+    document.hidden;
+    jtd.setTheme(newColorScheme);
+    localStorage.setItem('color-scheme', newColorScheme);
+
+    window.addEventListener('DOMContentLoaded', function () {
+      setThemeIcon(newColorScheme);
+    });
+  } else {
+    jtd.setTheme(localStorage.getItem('color-scheme'));
+    window.addEventListener('DOMContentLoaded', function () {
+      setThemeIcon(localStorage.getItem('color-scheme'));
+    });
+  }
+
+  window
+    .matchMedia('(prefers-color-scheme: dark)')
+    .addEventListener('change', (event) => {
+      if (localStorage.getItem('color-scheme') === null) {
+        const newColorScheme = event.matches ? 'dark' : 'light';
+        jtd.setTheme(newColorScheme);
+        setThemeIcon(newColorScheme);
+        localStorage.setItem('color-scheme', newColorScheme);
+      }
+    });
+
+  window.addEventListener('DOMContentLoaded', function () {
+    const toggleDarkMode = document.getElementById('theme-toggle');
+    jtd.addEvent(toggleDarkMode, 'click', function () {
+      const newColorScheme = jtd.getTheme() !== 'dark' ? 'dark' : 'light';
+      jtd.setTheme(newColorScheme);
+      setThemeIcon(newColorScheme);
+      localStorage.setItem('color-scheme', newColorScheme);
+    });
+  });
+})(window.jtd);

--- a/src/_includes/js/custom.js
+++ b/src/_includes/js/custom.js
@@ -55,9 +55,5 @@
       localStorage.setItem('color-scheme', newColorScheme);
     });
 
-    const editButton = document.getElementById('edit-button');
-    jtd.addEvent(editButton, 'click', function () {
-      location.href = 'https://github.com/Laserfiche/laserfiche.github.io';
-    });
   });
 })(window.jtd);

--- a/src/_includes/js/custom.js
+++ b/src/_includes/js/custom.js
@@ -7,14 +7,17 @@
     const svg = toggleDarkMode.querySelector('use');
     if (theme === 'dark') {
       svg.setAttribute('href', '#svg-sun');
+      toggleDarkMode.setAttribute('title', 'Light mode');
     } else {
       svg.setAttribute('href', '#svg-moon');
+      toggleDarkMode.setAttribute('title', 'Dark mode');
     }
   }
+
   if (localStorage.getItem('color-scheme') === null) {
     const newColorScheme =
       window.matchMedia &&
-      window.matchMedia('(prefers-color-scheme: dark)').matches
+        window.matchMedia('(prefers-color-scheme: dark)').matches
         ? 'dark'
         : 'light';
 
@@ -50,6 +53,11 @@
       jtd.setTheme(newColorScheme);
       setThemeIcon(newColorScheme);
       localStorage.setItem('color-scheme', newColorScheme);
+    });
+
+    const editButton = document.getElementById('edit-button');
+    jtd.addEvent(editButton, 'click', function () {
+      location.href = 'https://github.com/Laserfiche/laserfiche.github.io';
     });
   });
 })(window.jtd);

--- a/src/_sass/color_schemes/dark.scss
+++ b/src/_sass/color_schemes/dark.scss
@@ -2,7 +2,7 @@ $color-scheme: dark;
 $body-background-color: $grey-dk-300;
 $body-heading-color: $grey-lt-000;
 $body-text-color: $grey-lt-300;
-$link-color: $lf-link;
+$link-color: lighten($lf-link, 25%);
 $nav-child-link-color: $grey-dk-000;
 $sidebar-color: $grey-dk-300;
 $base-button-color: $grey-dk-250;
@@ -14,5 +14,7 @@ $table-background-color: $grey-dk-250;
 $search-background-color: $grey-dk-250;
 $search-result-preview-color: $grey-dk-000;
 $border-color: $grey-dk-200;
+$note-bg-color: #4b3d18;
+$lf-orange: lighten($lf-orange, 10%);
 
 @import "./vendor/OneDarkJekyll/syntax"; // this is the one-dark-vivid atom syntax theme

--- a/src/_sass/color_schemes/dark.scss
+++ b/src/_sass/color_schemes/dark.scss
@@ -14,7 +14,7 @@ $table-background-color: $grey-dk-250;
 $search-background-color: $grey-dk-250;
 $search-result-preview-color: $grey-dk-000;
 $border-color: $grey-dk-200;
-$note-bg-color: #4b3d18;
+$note-bg-color: #4e3d16;
 $lf-orange: lighten($lf-orange, 10%);
 
 @import "./vendor/OneDarkJekyll/syntax"; // this is the one-dark-vivid atom syntax theme

--- a/src/_sass/color_schemes/light.scss
+++ b/src/_sass/color_schemes/light.scss
@@ -12,5 +12,6 @@ $feedback-color: darken($sidebar-color, 3%) !default;
 $table-background-color: $white !default;
 $search-background-color: $white !default;
 $search-result-preview-color: $grey-dk-000 !default;
+$note-bg-color: #FFEEC1;
 
 @import "./vendor/OneLightJekyll/syntax";

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -135,17 +135,20 @@
     background-color: $note-bg-color;
   }
 }
-#theme-toggle {
-  width: $sp-8;
-  height: $sp-8;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  align-self: center;
-  margin-right: $sp-1;
-}
-// @media (min-width: $value) {
-//   #theme-toggle {
-//     width: ;
-//   }
+// #theme-toggle {
+//   // width: $sp-8;
+//   // height: $sp-8;
+//   display: flex;
+//   justify-content: center;
+//   align-items: center;
+//   align-self: center;
+//   margin-right: $sp-2;
+
 // }
+
+#theme-toggle {
+  margin-left: auto;
+  @include mq(lg) {
+    margin-left: unset;
+  }
+}

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -1,6 +1,6 @@
 #footer {
   min-height: $min-footer-height;
-  background-color: rgb(252, 252, 252);
+  background-color: $body-background-color;
   a:not([class]) {
     text-decoration: none;
   }
@@ -10,7 +10,7 @@
     padding-inline-start: 0px;
     margin: 12px;
     margin-left: 0px;
-    
+
     li {
       &::before {
         content: none;
@@ -56,7 +56,7 @@
       font-weight: bold;
       color: $lf-orange;
       margin: 10px;
-      margin-right:0px;
+      margin-right: 0px;
     }
 
     .Resources,
@@ -75,14 +75,14 @@
         }
         .sub-menu {
           div {
-            color: #222c33;
+            color: $body-text-color;
             font-weight: normal;
           }
         }
         #ot-sdk-btn {
           border: none !important;
           background: transparent;
-          color: #222c33;
+          color: $body-text-color;
           display: inline-block;
           font-size: 1rem;
           font-weight: 400;
@@ -129,3 +129,23 @@
   position: absolute;
   width: 1px;
 }
+
+.main-content {
+  .note {
+    background-color: $note-bg-color;
+  }
+}
+#theme-toggle {
+  width: $sp-8;
+  height: $sp-8;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  align-self: center;
+  margin-right: $sp-1;
+}
+// @media (min-width: $value) {
+//   #theme-toggle {
+//     width: ;
+//   }
+// }

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -135,16 +135,6 @@
     background-color: $note-bg-color;
   }
 }
-// #theme-toggle {
-//   // width: $sp-8;
-//   // height: $sp-8;
-//   display: flex;
-//   justify-content: center;
-//   align-items: center;
-//   align-self: center;
-//   margin-right: $sp-2;
-
-// }
 
 #theme-toggle {
   margin-left: auto;

--- a/src/_sass/custom/custom.scss
+++ b/src/_sass/custom/custom.scss
@@ -1,4 +1,4 @@
-#footer {
+  #footer {
   min-height: $min-footer-height;
   background-color: $body-background-color;
   a:not([class]) {

--- a/src/_sass/navigation.scss
+++ b/src/_sass/navigation.scss
@@ -59,7 +59,7 @@
         font-weight: 600;
         text-decoration: none;
       }
-      
+
       &:hover,
       &.active {
         background-image: linear-gradient(-90deg,

--- a/src/_sass/navigation.scss
+++ b/src/_sass/navigation.scss
@@ -23,10 +23,13 @@
       padding-top: $sp-1;
       padding-bottom: $sp-1;
       line-height: #{$nav-list-item-height-sm - 2 * $sp-1};
+
       @if $nav-list-expander-right {
         padding-right: $nav-list-item-height-sm;
         padding-left: $gutter-spacing-sm;
-      } @else {
+      }
+
+      @else {
         padding-right: $gutter-spacing-sm;
         padding-left: $nav-list-item-height-sm;
       }
@@ -34,16 +37,19 @@
       @include mq(md) {
         min-height: $nav-list-item-height;
         line-height: #{$nav-list-item-height - 2 * $sp-1};
+
         @if $nav-list-expander-right {
           padding-right: $nav-list-item-height;
           padding-left: $gutter-spacing;
-        } @else {
+        }
+
+        @else {
           padding-right: $gutter-spacing;
           padding-left: $nav-list-item-height;
         }
       }
 
-      &.external > svg {
+      &.external>svg {
         width: $sp-4;
         height: $sp-4;
         vertical-align: text-bottom;
@@ -55,18 +61,18 @@
       }
 
       &:hover,
+      &:hover,
       &.active {
-        background-image: linear-gradient(
-          -90deg,
-          rgba($feedback-color, 1) 0%,
-          rgba($feedback-color, 0.8) 80%,
-          rgba($feedback-color, 0) 100%
-        );
+        background-image: linear-gradient(-90deg,
+            rgba($feedback-color, 1) 0%,
+            rgba($feedback-color, 0.8) 80%,
+            rgba($feedback-color, 0) 100%);
       }
     }
 
     .nav-list-expander {
       position: absolute;
+
       @if $nav-list-expander-right {
         right: 0;
       }
@@ -83,11 +89,9 @@
       }
 
       &:hover {
-        background-image: linear-gradient(
-          -90deg,
-          rgba($feedback-color, 1) 0%,
-          rgba($feedback-color, 0.8) 100%
-        );
+        background-image: linear-gradient(-90deg,
+            rgba($feedback-color, 1) 0%,
+            rgba($feedback-color, 0.8) 100%);
       }
 
       @if $nav-list-expander-right {
@@ -97,7 +101,7 @@
       }
     }
 
-    > .nav-list {
+    >.nav-list {
       display: none;
       padding-left: $sp-3;
       list-style: none;
@@ -116,15 +120,17 @@
     }
 
     &.active {
-      > .nav-list-expander svg {
+      >.nav-list-expander svg {
         @if $nav-list-expander-right {
           transform: rotate(-90deg);
-        } @else {
+        }
+
+        @else {
           transform: rotate(90deg);
         }
       }
 
-      > .nav-list {
+      >.nav-list {
         display: block;
       }
     }
@@ -151,18 +157,18 @@
 }
 
 .nav-list.nav-category-list {
-  > .nav-list-item {
+  >.nav-list-item {
     margin: 0;
 
-    > .nav-list {
+    >.nav-list {
       padding: 0;
 
-      > .nav-list-item {
-        > .nav-list-link {
+      >.nav-list-item {
+        >.nav-list-link {
           color: $link-color;
         }
 
-        > .nav-list-expander {
+        >.nav-list-expander {
           color: $link-color;
         }
       }

--- a/src/_sass/navigation.scss
+++ b/src/_sass/navigation.scss
@@ -59,8 +59,7 @@
         font-weight: 600;
         text-decoration: none;
       }
-
-      &:hover,
+      
       &:hover,
       &.active {
         background-image: linear-gradient(-90deg,

--- a/src/docs/guides/guide-laserfiche-tables/index.md
+++ b/src/docs/guides/guide-laserfiche-tables/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Working with Reporting Applications
-nav_order: 7
+nav_order: 8
 has_children: false
 parent: Guides
 ---


### PR DESCRIPTION
Notes:

- Attempted to maintain best practice in adding the toggle to jtd custom docs only
- new header_custom only allowed placing the icon within the menu bar on < large screen sizes. Would have preferred to put it to the left of the menu icon in those screen sizes, but opted for only editing custom marked files
- Dark mode does not directly conform to any LF color scheme. I opted for the closest color of blue that met WCAG contrast guidelines against the default dark mode background color. Orange worked out just fine on both.
- Update the custom CSS for the page footer to use the default SASS variables for text color so they would update appropriately when themes are toggled using ootb jtd theme.