### PR TITLE
Documentation: Repository API V2 page manipulation and document lifec…

### DIFF
--- a/src/docs/api/repository-api-reference/index.md
+++ b/src/docs/api/repository-api-reference/index.md
@@ -22,6 +22,9 @@ Each entry can have associated **metadata** such as **fields** and **templates**
 Laserfiche Repository API enables programmatic access to [Cloud](https://doc.laserfiche.com/laserfiche/en-us/content/intro-welcome-to-laserfiche.htm) and [Self-Hosted](https://doc.laserfiche.com/laserfiche.documentation/12/userguide/en-us/content/intro-getting-started.htm) Laserfiche Repositories:
 
 - [Create, list, import, and export documents and folders](../../guides/documents-and-folders/)
+- [Update documents — electronic document, metadata, and image pages](../../guides/documents-and-folders/guide_updating-documents/)
+- [Manipulate pages — create, replace, rotate, move, copy, and delete](../../guides/documents-and-folders/guide_page-manipulation/)
+- [Manage document locks and versions — lock / unlock, check-in / check-out](../../guides/documents-and-folders/guide_document-lifecycle/)
 - [Read/Write entry metadata](../../guides/metadata/)
 - [Search the Repository](../../guides/search/)
 

--- a/src/docs/guides/documents-and-folders/guide_document-lifecycle/index.md
+++ b/src/docs/guides/documents-and-folders/guide_document-lifecycle/index.md
@@ -10,7 +10,7 @@ grand_parent: Guides
 See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
 
 # Document Lifecycle — Locks and Version Control
-**Applies to**: Repository API v2.
+**Applies to**: Repository API v2 Cloud.
 
 Laserfiche documents support two related but distinct coordination mechanisms: **persistent locks**, which prevent concurrent modifications, and **version control** (check-in / check-out), which integrates with the repository's version history. Version control uses locks internally but adds the concept of explicit versions, check-out state, and undo.
 
@@ -201,15 +201,15 @@ The document entry returned by `GET /Entries/{entryId}` surfaces both lock and v
 | Property | Type | Description |
 |---|---|---|
 | `isLocked` | bool | Whether the document has a persistent lock. |
-| `lockedBy` | string (nullable) | Account name of the lock holder, or null if not locked. |
+| `lockedBy` | string (nullable) | Display name of the lock holder, or null if not locked. |
 | `isLockedByAnotherUser` | bool | True if locked by a user other than the caller. |
 | `isCheckedOut` | bool | Whether the document is checked out. |
-| `checkedOutBy` | string (nullable) | Account name of the user holding the check-out, or null. |
+| `checkedOutBy` | string (nullable) | Display name of the user holding the check-out, or null. |
 | `isCheckedOutByAnotherUser` | bool | True if checked out by a user other than the caller. |
 | `isUnderVersionControl` | bool | Whether the document is under version control. |
 | `currentVersion` | int | Version number; `0` if not under version control. |
 
-`lockedBy` and `checkedOutBy` resolve the stored SID to an account name. `isLockedByAnotherUser` and `isCheckedOutByAnotherUser` let clients distinguish their own hold from a foreign hold without comparing account names.
+`lockedBy` and `checkedOutBy` are display names — useful for UI rendering, but not unique across users. To distinguish your own hold from a foreign hold reliably, use `isLockedByAnotherUser` and `isCheckedOutByAnotherUser`; these are computed server-side from stable principal identifiers, not from the display name.
 
 ## See also
 

--- a/src/docs/guides/documents-and-folders/guide_document-lifecycle/index.md
+++ b/src/docs/guides/documents-and-folders/guide_document-lifecycle/index.md
@@ -1,0 +1,218 @@
+---
+layout: default
+title: Document Lifecycle — Locks and Version Control
+nav_order: 7
+parent: Repository Folders and Documents
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Document Lifecycle — Locks and Version Control
+**Applies to**: Repository API v2.
+
+Laserfiche documents support two related but distinct coordination mechanisms: **persistent locks**, which prevent concurrent modifications, and **version control** (check-in / check-out), which integrates with the repository's version history. Version control uses locks internally but adds the concept of explicit versions, check-out state, and undo.
+
+This guide covers both and their interaction.
+
+## Persistent Locks
+
+Persistent locks survive session disconnect and server restart. They carry a lock token, an owner, an optional comment, and an *extent* — the subset of the document the lock protects.
+
+### Acquire a Lock
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Lock
+```
+
+Request body (all fields optional):
+
+```json
+{
+  "comment": "Processing monthly AP run",
+  "extent": "All"
+}
+```
+
+`extent` accepts `Page`, `Edoc`, `Metadata`, or `All` (default). A narrower extent allows unrelated modifications — e.g. an `Edoc` lock prevents changes to the electronic document but still allows metadata edits.
+
+Response:
+
+```json
+{
+  "lockToken": "01HW7K...",
+  "owner": "alice",
+  "comment": "Processing monthly AP run",
+  "extent": "All",
+  "creationTimestampUtc": "2026-04-21T18:30:00Z",
+  "isActive": true
+}
+```
+
+Record the `lockToken` — it's required for administrative unlock (see below).
+
+### Inspect Lock State
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Lock
+```
+
+Returns the current lock's details, or an empty/inactive `LockInfo` if not locked.
+
+### Release a Lock
+
+Current user's own lock:
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Lock
+```
+
+Administrative unlock of another user's lock (requires appropriate permissions):
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Lock?lockToken={token}
+```
+
+Both return 204 No Content.
+
+### Locks — client libraries
+
+**.NET**
+
+```csharp
+var lockInfo = await client.EntriesClient.LockDocumentAsync(new LockDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    Request = new LockDocumentRequest
+    {
+        Comment = "Processing monthly AP run",
+        Extent = LockDocumentRequestExtent.All,
+    },
+});
+
+// ... perform writes ...
+
+await client.EntriesClient.UnlockDocumentAsync(new UnlockDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+});
+```
+
+## Version Control
+
+Version control is opt-in per document. A document not under version control accepts writes in-place without creating versions. A document under version control requires an explicit check-out before modifications; each check-in creates a new version.
+
+### Enable Version Control
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/VersionControl
+```
+
+Puts the document under version control. No-op if already under version control.
+
+### Check Out
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/CheckOut
+```
+
+Request body (all fields optional):
+
+```json
+{
+  "lock": true,
+  "comment": "Editing for Q2 review"
+}
+```
+
+- `lock` (default `true`) — when `true`, the server also acquires a persistent lock as part of the check-out. Set to `false` when another coordination mechanism is already in place (e.g. an application-level queue).
+- `comment` — attached to the check-out state and visible via `GET /Entries/{entryId}`.
+
+Returns the updated document entry.
+
+### Check In
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/CheckIn
+```
+
+Request body (optional):
+
+```json
+{
+  "unlock": false
+}
+```
+
+- `unlock` (default `true`) — when `true`, any persistent lock held on the document is released as part of the check-in. Set to `false` to retain the lock across the check-in, enabling back-to-back check-out / check-in cycles under one continuous lock.
+
+Creates a new version and returns the updated document entry.
+
+### Undo Check Out
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/UndoCheckOut
+```
+
+Releases the check-out state without creating a new version. Any changes made to the working copy are discarded. Used when an editing operation fails or is cancelled.
+
+### Version control — client libraries
+
+**.NET**
+
+```csharp
+await client.EntriesClient.PutUnderVersionControlAsync(new PutUnderVersionControlParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+});
+
+await client.EntriesClient.CheckOutDocumentAsync(new CheckOutDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    Request = new CheckOutDocumentRequest { Lock = true, Comment = "Q2 edit pass" },
+});
+
+// ... perform writes via PATCH /Document or page-manipulation endpoints ...
+
+await client.EntriesClient.CheckInDocumentAsync(new CheckInDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    Request = new CheckInDocumentRequest { Unlock = true },
+});
+```
+
+## Interaction Between Locks and Version Control
+
+- A `CheckOut` with `lock=true` acquires a persistent lock alongside the check-out state. They are released together by a `CheckIn` with `unlock=true` (the default).
+- A `CheckIn` with `unlock=false` releases the check-out but retains the lock, so the same caller can immediately `CheckOut` again without a window where another user could interfere.
+- A standalone `LockDocument` followed by a `CheckOut` is equivalent to `CheckOut` with `lock=true` — the existing lock is honored and not duplicated.
+- An administrative unlock (via `?lockToken={token}`) does not undo a check-out. Use `UndoCheckOut` to release check-out state.
+
+## Document Response Fields
+
+The document entry returned by `GET /Entries/{entryId}` surfaces both lock and version control state directly — no separate call is needed for common visibility checks.
+
+| Property | Type | Description |
+|---|---|---|
+| `isLocked` | bool | Whether the document has a persistent lock. |
+| `lockedBy` | string (nullable) | Account name of the lock holder, or null if not locked. |
+| `isLockedByAnotherUser` | bool | True if locked by a user other than the caller. |
+| `isCheckedOut` | bool | Whether the document is checked out. |
+| `checkedOutBy` | string (nullable) | Account name of the user holding the check-out, or null. |
+| `isCheckedOutByAnotherUser` | bool | True if checked out by a user other than the caller. |
+| `isUnderVersionControl` | bool | Whether the document is under version control. |
+| `currentVersion` | int | Version number; `0` if not under version control. |
+
+`lockedBy` and `checkedOutBy` resolve the stored SID to an account name. `isLockedByAnotherUser` and `isCheckedOutByAnotherUser` let clients distinguish their own hold from a foreign hold without comparing account names.
+
+## See also
+
+- [Update Documents](../guide_updating-documents/) — electronic document, metadata, and image-page updates (auto-wraps in CheckOut / CheckIn when appropriate)
+- [Manipulate Document Pages](../guide_page-manipulation/) — per-page image and text operations
+- [Repository API V2 changelog](https://api.laserfiche.com/repository/v2/changelog) — authoritative endpoint reference

--- a/src/docs/guides/documents-and-folders/guide_importing-documents/index.md
+++ b/src/docs/guides/documents-and-folders/guide_importing-documents/index.md
@@ -22,6 +22,11 @@ Laserfiche API V2 provides two types of APIs for importing a document:
 - **Simple Import:** this is intended to be used for importing _small_ documents in a _synchronous_ style. The current maximum file size limit for this API is 100 MB.
 - **Chunked Import:** this is intended to be used for importing _large_ documents in an _asynchronous_ style, i.e. using the [long operation](../../../getting-started/guide_long-operations/) pattern. The current maximum file size limit for this API is 64 GB.
 
+The Import endpoint also supports two adjacent flows beyond a traditional file upload:
+
+- **Empty document:** omit the `file` part (or supply a zero-length file) to create a document entry with no electronic document and no pages. See the [Update Documents guide](../guide_updating-documents/) for adding an electronic document and pages later.
+- **Document with image pages:** supply an optional `imageFiles` part alongside (or instead of) a `file` to attach image pages as part of import. See the [Manipulate Document Pages guide](../guide_page-manipulation/) for per-page operations.
+
 ## Simple Import
 
 Create a document with the Laserfiche API by using the following multipart/form POST request.

--- a/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
+++ b/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
@@ -10,7 +10,7 @@ grand_parent: Guides
 See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
 
 # Manipulate Document Pages
-**Applies to**: Repository API v2.
+**Applies to**: Repository API v2 Cloud.
 
 A Laserfiche document is a composite object with three independent components: an optional electronic document (the original source file — PDF, DOCX, etc.), image pages (rasterized page images), and text pages (searchable text per page). Page manipulation operations in this guide target image and text pages only; the electronic document is covered by the [Update Documents guide](../guide_updating-documents/).
 

--- a/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
+++ b/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
@@ -228,6 +228,32 @@ GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries
 
 `pageRange` is optional; when omitted, metadata is returned for every page.
 
+### Paginating page metadata
+
+`ListPageInfos` returns a paged OData collection. The default page size is **150**; the response envelope includes `value` (the list), `@odata.count` (total when `$count=true`), and `@odata.nextLink` when more pages remain.
+
+```
+GET .../Document/Pages?$top=50&$count=true
+```
+
+```json
+{
+  "@odata.count": 1240,
+  "value": [ /* up to 50 PageInfoResponse items */ ],
+  "@odata.nextLink": "https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages?%24skiptoken=..."
+}
+```
+
+Supported query options: `$top`, `$count`, `$select`, `$skiptoken`. `$orderby` is not supported — pages are inherently ordered by page number. To set the page size via the OData header convention instead of `$top`, send `Prefer: odata.maxpagesize=N`.
+
+`pageRange` composes with paging — the range is applied first, then paging is applied to the filtered result. For example, fetch page metadata 100-300 in chunks of 50:
+
+```
+GET .../Document/Pages?pageRange=100-300&$top=50
+```
+
+To page through, follow `@odata.nextLink` until it is no longer returned.
+
 ## Generate Text for All Image Pages
 
 Trigger server-side OCR across every image page in the document. Existing text is overwritten per page.

--- a/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
+++ b/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
@@ -67,10 +67,10 @@ Set `?pageNumber=5`. Three empty pages are inserted at positions 5, 6, 7; existi
 **JavaScript**
 
 ```javascript
-import { RepositoryApiClient, CreatePagesRequest } from '@laserfiche/lf-repository-api-client-v2';
+import { RepositoryApiClient, PagesContentRequest } from '@laserfiche/lf-repository-api-client-v2';
 
 const client = RepositoryApiClient.createFromAccessKey(servicePrincipalKey, accessKey);
-const request = new CreatePagesRequest();
+const request = new PagesContentRequest();
 request.textPages = ['Searchable text for the page'];
 
 await client.entriesClient.createPages({
@@ -96,7 +96,7 @@ await client.EntriesClient.CreatePagesAsync(new CreatePagesParameters
     {
         new FileParameter(pngStream, "scan.png", "image/png"),
     },
-    Request = new CreatePagesRequest
+    Request = new PagesContentRequest
     {
         TextPages = new List<string> { "Searchable text for the page" },
     },
@@ -118,7 +118,7 @@ Same multipart shape and pairing semantics as `POST Pages`. If both `imageFiles`
 Overwrite the image part, text part, or both of an existing page. Parts not provided are left unchanged.
 
 ```
-PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})
+PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages/{pageNumber}
 ```
 
 Request parts:
@@ -196,7 +196,7 @@ POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entrie
 Rotate the image on a single page. Text on the page is unaffected.
 
 ```
-POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Image/Rotate
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages/{pageNumber}/Image/Rotate
 ```
 
 ```json
@@ -212,8 +212,8 @@ Accepted angles: `0`, `90`, `180`, `270`.
 Per-page GETs return the image binary or the text content directly.
 
 ```
-GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Image
-GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Text
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages/{pageNumber}/Image
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages/{pageNumber}/Text
 ```
 
 `Image` returns a binary stream (typically TIFF, JPG, or PNG depending on how the page was produced). `Text` returns a JSON body with a `text` property.

--- a/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
+++ b/src/docs/guides/documents-and-folders/guide_page-manipulation/index.md
@@ -1,0 +1,245 @@
+---
+layout: default
+title: Manipulate Document Pages
+nav_order: 6
+parent: Repository Folders and Documents
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Manipulate Document Pages
+**Applies to**: Repository API v2.
+
+A Laserfiche document is a composite object with three independent components: an optional electronic document (the original source file — PDF, DOCX, etc.), image pages (rasterized page images), and text pages (searchable text per page). Page manipulation operations in this guide target image and text pages only; the electronic document is covered by the [Update Documents guide](../guide_updating-documents/).
+
+Both page parts are independent and optional: a page can have an image only, text only, both, or neither (empty page). Writing either part is always a full overwrite — there is no partial update.
+
+All page endpoints are scoped to a single document entry and rooted at:
+
+```
+v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages
+```
+
+## Create Pages
+
+Create one or more pages on a document. Images and text content are paired by index — the `N`th `imageFiles` entry and the `N`th `textPages` entry belong to the same page. Either array may be shorter (the corresponding page is created without that part) or absent (one empty page is created when both are empty).
+
+**Request Overview**
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages
+```
+
+The request is `multipart/form-data`:
+
+- `imageFiles` (optional): up to 10 image files (TIFF, JPG, PNG), 100 MB aggregate.
+- `request` (optional): JSON part with `textPages: string[]` — one entry per text page.
+
+Query parameters:
+
+- `pageNumber` (optional): 1-based insertion position. Omit to append at the end.
+- `generateText` (optional, default `false`): trigger OCR on the resulting image pages after creation. When `true`, any supplied `textPages` for those same indexes are ignored — OCR output would overwrite them.
+
+**Sample: append one image page and one text page**
+
+```json
+{
+  "textPages": ["Searchable text for the second page"]
+}
+```
+
+Attach a PNG as `imageFiles[0]`; the JSON above as the `request` part; the result is two pages appended (image-only on page N, text-only on page N+1). To pair the image and text on a single page, supply a single `imageFiles` entry *and* a single `textPages[0]`.
+
+**Sample: insert three empty pages at position 5**
+
+```json
+{
+  "textPages": ["", "", ""]
+}
+```
+
+Set `?pageNumber=5`. Three empty pages are inserted at positions 5, 6, 7; existing page 5 and beyond shift down accordingly.
+
+### Create Pages — client libraries
+
+**JavaScript**
+
+```javascript
+import { RepositoryApiClient, CreatePagesRequest } from '@laserfiche/lf-repository-api-client-v2';
+
+const client = RepositoryApiClient.createFromAccessKey(servicePrincipalKey, accessKey);
+const request = new CreatePagesRequest();
+request.textPages = ['Searchable text for the page'];
+
+await client.entriesClient.createPages({
+  repositoryId,
+  entryId,
+  imageFiles: [{ fileName: 'scan.png', data: pngBlob }],
+  request,
+});
+```
+
+**.NET**
+
+```csharp
+using Laserfiche.Repository.Api.Client;
+
+var client = RepositoryApiClient.CreateFromAccessKey(servicePrincipalKey, accessKey);
+
+await client.EntriesClient.CreatePagesAsync(new CreatePagesParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    ImageFiles = new List<FileParameter>
+    {
+        new FileParameter(pngStream, "scan.png", "image/png"),
+    },
+    Request = new CreatePagesRequest
+    {
+        TextPages = new List<string> { "Searchable text for the page" },
+    },
+});
+```
+
+## Replace All Pages
+
+Delete every existing page on the document and create new pages from the supplied inputs — all in a single request, under one lock scope, producing one auto-version (if the document is under version control).
+
+```
+PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages
+```
+
+Same multipart shape and pairing semantics as `POST Pages`. If both `imageFiles` and `textPages` are empty or absent, all pages are deleted.
+
+## Modify a Single Page
+
+Overwrite the image part, text part, or both of an existing page. Parts not provided are left unchanged.
+
+```
+PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})
+```
+
+Request parts:
+
+- `imageFile` (optional): single image file.
+- `request` (optional): JSON with `text: string`.
+
+At least one of `imageFile` or `request.text` must be provided.
+
+**Sample: replace only the text on page 3**
+
+```json
+{
+  "text": "Corrected OCR text for page 3"
+}
+```
+
+**.NET**
+
+```csharp
+await client.EntriesClient.WritePageAsync(new WritePageParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    PageNumber = 3,
+    Request = new WritePageTextRequest { Text = "Corrected OCR text for page 3" },
+});
+```
+
+## Delete Pages
+
+Remove a range or all pages on the document.
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages?pageRange={range}
+```
+
+`pageRange` is a comma-separated mix of single values and hyphenated ranges: `"1,3,5"`, `"2-4,7"`, `"1-3,5,8-10"`. Omit to delete every page.
+
+## Move Pages Within a Document
+
+Reorder pages within the same document.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages/Move
+```
+
+```json
+{
+  "pageRange": "2-4",
+  "destinationPageNumber": 8
+}
+```
+
+Pages 2, 3, and 4 are removed from their current positions and reinserted starting at position 8 (in their original relative order).
+
+## Copy Pages Across Documents
+
+Copy pages from one document to another. The source document retains its pages; copies are inserted into the destination.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{sourceEntryId}/Document/Pages/Copy
+```
+
+```json
+{
+  "pageRange": "1-3",
+  "destinationEntryId": 12345,
+  "destinationPageNumber": 1
+}
+```
+
+## Rotate an Image Page
+
+Rotate the image on a single page. Text on the page is unaffected.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Image/Rotate
+```
+
+```json
+{
+  "rotationAngle": 90
+}
+```
+
+Accepted angles: `0`, `90`, `180`, `270`.
+
+## Retrieve Page Content
+
+Per-page GETs return the image binary or the text content directly.
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Image
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages({pageNumber})/Text
+```
+
+`Image` returns a binary stream (typically TIFF, JPG, or PNG depending on how the page was produced). `Text` returns a JSON body with a `text` property.
+
+## List Page Metadata
+
+Retrieve per-page metadata (image presence, text presence, dimensions) without downloading the content.
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Pages?pageRange={range}
+```
+
+`pageRange` is optional; when omitted, metadata is returned for every page.
+
+## Generate Text for All Image Pages
+
+Trigger server-side OCR across every image page in the document. Existing text is overwritten per page.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/GenerateText
+```
+
+Returns the updated document entry.
+
+## See also
+
+- [Update Documents](../guide_updating-documents/) — electronic document, metadata, and image-page updates in a single request
+- [Document Lifecycle](../guide_document-lifecycle/) — locks and version control
+- [Repository API V2 changelog](https://api.laserfiche.com/repository/v2/changelog) — authoritative endpoint reference

--- a/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
+++ b/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
@@ -10,7 +10,7 @@ grand_parent: Guides
 See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
 
 # Update Documents
-**Applies to**: Repository API v2.
+**Applies to**: Repository API v2 Cloud.
 
 A Laserfiche document has three independent components: an optional electronic document (the original source file, e.g. PDF), image pages, and text pages. This guide covers creating documents from nothing, updating their electronic document, updating their metadata, and managing their template assignment. For per-page image and text operations see the [Manipulate Document Pages guide](../guide_page-manipulation/).
 
@@ -50,7 +50,7 @@ Example `request` body:
 
 ```json
 {
-  "name": "LFAPI created document with image pages",
+  "name": "Email with scanned attachments",
   "autoRename": true,
   "generateImagePagesText": true,
   "metadata": {

--- a/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
+++ b/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
@@ -151,27 +151,6 @@ POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entrie
 
 Returns a 202 Accepted with a task ID — poll `/Tasks?taskIds={taskId}` for completion. The async path is caller-managed for version control: pre-`CheckOut` the document if you need a single-version outcome. The connector does not auto-wrap async updates in CheckOut/CheckIn.
 
-## Download the Electronic Document
-
-```
-GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document
-```
-
-Returns the electronic document as a binary stream. The response's `Content-Type` header reflects the stored MIME type.
-
-**.NET**
-
-```csharp
-using var response = await client.EntriesClient.GetDocumentAsync(new GetDocumentParameters
-{
-    RepositoryId = repositoryId,
-    EntryId = entryId,
-});
-
-using var outputFile = File.Create("downloaded.pdf");
-await response.Stream.CopyToAsync(outputFile);
-```
-
 ## Delete the Electronic Document
 
 Remove the electronic document without affecting image pages, text pages, or metadata. Useful when the electronic document is no longer canonical but the image pages remain the authoritative representation.

--- a/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
+++ b/src/docs/guides/documents-and-folders/guide_updating-documents/index.md
@@ -1,0 +1,215 @@
+---
+layout: default
+title: Update Documents
+nav_order: 5
+parent: Repository Folders and Documents
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Update Documents
+**Applies to**: Repository API v2.
+
+A Laserfiche document has three independent components: an optional electronic document (the original source file, e.g. PDF), image pages, and text pages. This guide covers creating documents from nothing, updating their electronic document, updating their metadata, and managing their template assignment. For per-page image and text operations see the [Manipulate Document Pages guide](../guide_page-manipulation/).
+
+All updates in this guide are **additive** by default: supplied metadata is merged with existing metadata, supplied image files are appended as new image pages, and the electronic document is replaced only when a new one is supplied.
+
+## Create an Empty Document
+
+Create a document entry with no electronic document and no pages. Use this when you intend to add pages or an electronic document later.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{parentEntryId}/Folder/Import
+```
+
+The request is `multipart/form-data`. Omit the `file` part entirely (or supply a zero-length `file`). The `request` JSON part carries the new document's name and any initial metadata:
+
+```json
+{
+  "name": "Empty document",
+  "autoRename": true,
+  "metadata": {
+    "templateName": "Email"
+  }
+}
+```
+
+The server creates a document entry with `pageCount: 0`, no electronic document, and no extension or MIME type constraints. Pages and an electronic document can be added later via the guides linked at the bottom of this page.
+
+## Import a Document with Image Pages
+
+The Import endpoint accepts an optional `imageFiles` multipart parameter — up to 10 images (TIFF, JPG, PNG), 100 MB aggregate — that become image pages on the newly created document after import completes. Independent of any electronic document uploaded via the `file` part.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{parentEntryId}/Folder/Import
+```
+
+Example `request` body:
+
+```json
+{
+  "name": "LFAPI created document with image pages",
+  "autoRename": true,
+  "generateImagePagesText": true,
+  "metadata": {
+    "templateName": "Email"
+  }
+}
+```
+
+- `generateImagePagesText` (optional, default `true`): runs OCR on the `imageFiles`-added pages after import. This is independent of `pdfOptions.generateText` which controls text extraction during PDF → image conversion.
+
+**Combining `file` and `imageFiles`**: allowed when the `file` itself would not be converted to image pages. A PDF or Word file plus `imageFiles` is fine — the file becomes the electronic document and `imageFiles` become pages. Supplying an image-extension `file` (TIFF, PNG, JPG) with `importAsElectronicDocument=false` *and* `imageFiles` is rejected with 400 because both inputs would produce pages.
+
+## Update a Document — Electronic Document, Metadata, and Image Pages
+
+The unified update endpoint touches all three document components in one additive request.
+
+```
+PATCH https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document
+```
+
+- The `file` part (optional) replaces the electronic document. A non-empty file replaces; omitting leaves the edoc unchanged. A zero-length `file` is rejected with 400 — remove the electronic document via `DELETE .../Document/Edoc` instead (see below).
+- The `imageFiles` part (optional, up to 10 files, 100 MB aggregate) appends as image pages. Use the `PUT .../Document/Pages` endpoint from the [page manipulation guide](../guide_page-manipulation/) if you need a full page replacement rather than an append.
+- The `metadata` block inside the `request` JSON is additive — only supplied fields, tags, links, and template assignments are touched. Existing values not in the request are preserved.
+
+At least one of `file`, `imageFiles`, or `metadata` must be provided.
+
+Example `request` body:
+
+```json
+{
+  "importAsElectronicDocument": true,
+  "generateImagePagesText": true,
+  "pdfOptions": {
+    "generateText": true,
+    "generatePages": true,
+    "generatePagesImageType": "StandardColor"
+  },
+  "metadata": {
+    "templateName": "Email",
+    "fields": [
+      { "name": "Sender", "values": ["sender@laserfiche.com"] }
+    ],
+    "tags": ["Reviewed"]
+  }
+}
+```
+
+**Metadata-only updates.** When no `file` or `imageFiles` are supplied, `PATCH /Document` applies metadata additively to the existing document without needing to re-submit the full field set. This replaces the older fetch-then-replace pattern required by `PUT /Entries/{entryId}/Fields`.
+
+**Interaction with version control.** If the document is under version control and already checked out by the caller, the update writes into the working copy and is committed atomically when the caller calls `CheckIn`. If the document is under version control and not checked out by the caller, the server transparently wraps the update in `CheckOut` → write → `CheckIn`, creating a single new version. See the [Document Lifecycle guide](../guide_document-lifecycle/) for explicit check-in / check-out flows.
+
+### Update Document — client libraries
+
+**.NET**
+
+```csharp
+await client.EntriesClient.UpdateDocumentAsync(new UpdateDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+    File = new FileParameter(pdfStream, "replacement.pdf", "application/pdf"),
+    ImageFiles = new List<FileParameter>
+    {
+        new FileParameter(pngStream, "attachment.png", "image/png"),
+    },
+    Request = new UpdateDocumentRequest
+    {
+        GenerateImagePagesText = true,
+        Metadata = new Metadata
+        {
+            Fields = new List<FieldValue>
+            {
+                new FieldValue { Name = "Reviewer", Values = new List<JToken> { JToken.FromObject("alice") } },
+            },
+        },
+    },
+});
+```
+
+## Update a Document Asynchronously (Large Files)
+
+Files that exceed the synchronous upload size limit are uploaded in chunks via the existing `CreateMultipartUploadUrls` endpoint (see the [Import Documents guide](../guide_importing-documents/) for the upload URL and chunk-writing steps), then assembled onto an existing document via `UpdateUploadedParts`.
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/UpdateUploadedParts
+```
+
+```json
+{
+  "uploadId": "YjBjMDBhZTUtNjMxMC00M2U0LThhZmMt==",
+  "partETags": ["etag1", "etag2", "..."],
+  "importAsElectronicDocument": true,
+  "metadata": {
+    "tags": ["Processed"]
+  }
+}
+```
+
+Returns a 202 Accepted with a task ID — poll `/Tasks?taskIds={taskId}` for completion. The async path is caller-managed for version control: pre-`CheckOut` the document if you need a single-version outcome. The connector does not auto-wrap async updates in CheckOut/CheckIn.
+
+## Download the Electronic Document
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document
+```
+
+Returns the electronic document as a binary stream. The response's `Content-Type` header reflects the stored MIME type.
+
+**.NET**
+
+```csharp
+using var response = await client.EntriesClient.GetDocumentAsync(new GetDocumentParameters
+{
+    RepositoryId = repositoryId,
+    EntryId = entryId,
+});
+
+using var outputFile = File.Create("downloaded.pdf");
+await response.Stream.CopyToAsync(outputFile);
+```
+
+## Delete the Electronic Document
+
+Remove the electronic document without affecting image pages, text pages, or metadata. Useful when the electronic document is no longer canonical but the image pages remain the authoritative representation.
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Document/Edoc
+```
+
+Returns 204 No Content.
+
+## Manage Template Assignment
+
+Template assignment and removal are full-replacement operations that apply to any entry type (documents, folders, shortcuts).
+
+```
+PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries({entryId})/Template
+```
+
+```json
+{
+  "templateName": "Invoice",
+  "fieldValues": [
+    { "name": "InvoiceNumber", "values": ["INV-2026-0042"] }
+  ]
+}
+```
+
+Full-replacement: existing field values for the previous template are discarded; only the fields supplied in `fieldValues` are applied for the new template. Use `PATCH /Document` for *additive* metadata updates on documents.
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries({entryId})/Template
+```
+
+Removes the template assignment.
+
+## See also
+
+- [Import Documents](../guide_importing-documents/) — create new documents
+- [Manipulate Document Pages](../guide_page-manipulation/) — per-page image and text operations
+- [Document Lifecycle](../guide_document-lifecycle/) — persistent locks and version control
+- [Repository API V2 changelog](https://api.laserfiche.com/repository/v2/changelog) — authoritative endpoint reference


### PR DESCRIPTION
Documentation for Repository API V2 page manipulation and document lifecycle 
  
  New guides under src/docs/guides/documents-and-folders/:

  - guide_page-manipulation/ — per-page image and text operations:
    CreatePages, ReplacePages, WritePage, DeletePages, MovePages, CopyPages,
    RotatePages, GetPageImage, GetPageText, list page metadata,
    GenerateText. HTTP examples plus JS and .NET client-library snippets.

  - guide_updating-documents/ — creating empty documents, importing with image pages, unified PATCH /Document (additive edoc + metadata + page append), chunked async updates via UpdateUploadedParts, edoc download and deletion, template assign/remove.

  - guide_document-lifecycle/ — persistent locks (acquire, inspect, release, administrative unlock via lockToken), version control     (PutUnderVersionControl, CheckOut, CheckIn, UndoCheckOut), lock / VC interaction rules, and document response fields that surface state (isLocked, lockedBy, isLockedByAnotherUser, isCheckedOut, checkedOutBy, isCheckedOutByAnotherUser, isUnderVersionControl, currentVersion).

  Also: cross-links from guide_importing-documents/ to the new guides and a nav entry under src/docs/api/repository-api-reference/.