### PR TITLE
Repository API V2 field & template definition admin and entry introspection guides

### DIFF
--- a/src/docs/guides/documents-and-folders/guide_entry-introspection/index.md
+++ b/src/docs/guides/documents-and-folders/guide_entry-introspection/index.md
@@ -1,0 +1,59 @@
+---
+layout: default
+title: Entry Introspection
+nav_order: 8
+parent: Repository Folders and Documents
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Entry Introspection
+**Applies to**: Repository API v2 Cloud.
+
+The Get Entry endpoint can return two additional, opt-in pieces of information: a summary of a folder's immediate children, and a document's total stored size. Both are comparatively expensive to compute, so they are **omitted from the response unless explicitly requested** — default entry reads and folder listings stay fast.
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}
+```
+
+Both facets require the `repository.Read` scope (the same as a normal entry read).
+
+## Folder Child Info
+
+Add `includeChildInfo=true` when reading a **folder** entry to include a `childInfo` object describing the folder's immediate children:
+
+```
+GET .../Entries/{entryId}?includeChildInfo=true
+```
+
+```jsonc
+"childInfo": {
+  "hasChildren": true,
+  "childCount": 42,      // total immediate children
+  "folderCount": 5,
+  "documentCount": 36,
+  "shortcutCount": 1
+}
+```
+
+- Counts are for **immediate children only** — recursive / whole-subtree counts are intentionally not offered.
+- Counts respect the caller's security rights (children the caller cannot see are not counted).
+- The `childInfo` object is omitted entirely when `includeChildInfo` is not supplied (it is not serialized as `null`).
+
+> **Prefer lazy expansion for tree navigation.** When rendering a folder tree, load each node's children on demand (optimistic lazy expansion) rather than requesting `childInfo` for every node up front. The facet is the opt-in escape hatch for the cases where you genuinely need a count without listing.
+
+## Document Total Size
+
+Add `includeTotalSize=true` when reading a **document** entry to include `totalDocumentSize`:
+
+```
+GET .../Entries/{entryId}?includeTotalSize=true
+```
+
+`totalDocumentSize` is the document's full stored size in bytes — the electronic document **plus** page image, text, locations, and thumbnail data and attachments. This is distinct from `electronicDocumentSize`, which counts only the source file. As a result `totalDocumentSize >= electronicDocumentSize`. The field is omitted when `includeTotalSize` is not supplied.
+
+## Already-available document fields
+
+For document entries, the Get Entry response already includes `pageCount`, `electronicDocumentSize`, and `extension` without any opt-in parameter, alongside the lock and version-control fields described in the [Document Lifecycle guide](../guide_document-lifecycle/).

--- a/src/docs/guides/metadata/guide_manage-field-definitions/index.md
+++ b/src/docs/guides/metadata/guide_manage-field-definitions/index.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: Manage Field Definitions
+nav_order: 6
+parent: Repository Metadata
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Manage Field Definitions
+**Applies to**: Repository API v2 Cloud.
+
+Field definitions describe the metadata fields available in a repository — their data type, format, constraints, list values, and behavior flags. These endpoints let repository administrators create and manage field definitions over REST; previously the `FieldDefinitions` surface was read-only (list and get).
+
+All field-definition endpoints are repository-scoped and rooted at:
+
+```
+v2/Repositories/{repositoryId}/FieldDefinitions
+```
+
+Creating, updating, and deleting field definitions requires the `repository.Write` scope; the introspection reads require `repository.Read`.
+
+## Create a Field Definition
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions
+```
+
+`name` and `fieldType` are required. `fieldType` is one of `String`, `List`, `Blob`, `Date`, `DateTime`, `Time`, `Number`, `ShortInteger`, `LongInteger`. The request also accepts the writable definition attributes and behavior flags:
+
+- `description`, `length` (max string length), `format` / `formatPattern`, `constraint` / `constraintError`, `currency`, `defaultValue`
+- `isIndexed`, `isIndexedForReporting`, `isMultiValue`, `isRequired`, `warnIfBlank`, `hideListValues`, `autoExtract`
+- `listValues` (string array) — initial pick-list values for a `List`-type field
+- `properties` — an optional extended key-value bag (see [Extended Properties](#extended-properties))
+
+**Sample: create an indexed single-line text field**
+
+```json
+{
+  "name": "Invoice Number",
+  "fieldType": "String",
+  "length": 40,
+  "isIndexed": true,
+  "description": "Vendor-supplied invoice identifier"
+}
+```
+
+The response is the created field definition, including its server-assigned `id`.
+
+A `List`-type field can be created with its values in the same request:
+
+```json
+{
+  "name": "Department",
+  "fieldType": "List",
+  "listValues": ["Accounting", "Legal", "Operations"]
+}
+```
+
+## Update a Field Definition
+
+```
+PATCH https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}
+```
+
+Partial update of the writable property set. Only properties present in the request are changed:
+
+- Omit a property (or send `null`) to leave it unchanged.
+- Send `""` to clear a string property.
+
+`fieldType` cannot be changed through this endpoint — use [Change a Field's Type](#change-a-fields-type). List values are managed through the dedicated [List Values](#manage-list-values) resource. Renaming is allowed; a name collision returns `400`.
+
+## Delete a Field Definition
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}
+```
+
+Returns `204 No Content` on success. If the field is still referenced by one or more templates or assigned to entries, the request is rejected with `409 Conflict` — remove those references first.
+
+## Manage List Values
+
+For `List`-backed fields, the pick-list values are managed through a dedicated sub-resource:
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues
+PUT https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ListValues
+```
+
+`GET` returns `{ "values": [ ... ] }` in list order. `PUT` replaces the full set wholesale, preserving the order you supply; an empty array clears the list. There is no partial add/remove — to add or remove a single value, GET the current values, modify the array, and PUT it back. Duplicate or empty values, and applying `PUT` to a non-list field, are rejected with `400`.
+
+```json
+{
+  "values": ["Accounting", "Legal", "Operations", "Facilities"]
+}
+```
+
+## Field Relationships and Usage
+
+Two read endpoints help you assess the impact of a change before making it:
+
+```
+GET .../FieldDefinitions/{fieldId}/ContainingTemplates
+GET .../FieldDefinitions/{fieldId}/AssignedEntryCount
+```
+
+- `ContainingTemplates` lists the template definitions that include this field.
+- `AssignedEntryCount` returns `{ "count": N }` — the number of entries currently using the field. Check both before deleting or changing the type of a widely used field.
+
+## Extended Properties
+
+Each field definition carries an extended key-value property bag — a string-to-string store for integration metadata, application-specific configuration, or external-system identifiers that should persist with the field definition (for example, list-field display preferences such as sort order).
+
+```
+GET .../FieldDefinitions/{fieldId}/Properties
+PATCH .../FieldDefinitions/{fieldId}/Properties
+```
+
+`PATCH` accepts `{ set: { ... }, remove: [ ... ] }` — `set` adds or overwrites the named keys, `remove` deletes them. The bag may also surface entries managed internally by the repository server; treat unknown keys as read-only.
+
+## Change a Field's Type
+
+See the [Destructive Field Operations](#destructive-field-operations) section below — changing a field's data type and merging fields are higher-risk operations gated by an explicit data-loss acknowledgement.
+
+## Destructive Field Operations
+
+Two operations consolidate or convert existing field definitions. Both are gated by an explicit `allowDataLoss` flag: when a request would lose data and `allowDataLoss` is not `true`, the server rejects it with `400` and a message naming what would be lost. The backend computes lossiness — the caller never has to.
+
+### Merge Fields
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/Merge
+```
+
+Merges the per-entry values of two or more existing fields into a **new** field.
+
+- `sourceFieldIds` — two or more field IDs (required).
+- `newFieldName` — name of the new merged field (required).
+- `onConflict` — `Fail` (default; abort on a per-entry value conflict), `MakeMultivalue` (keep all conflicting values — lossless), or `UseFirstField` (discard others — **lossy**, requires `allowDataLoss = true`).
+- `removeFromTemplates` (default `false`) — also remove the source fields from any templates that contain them.
+- `autoRename` (default `false`) — let the server pick a non-conflicting name if `newFieldName` collides (best-effort; honoring depends on repository version).
+
+The source field definitions are preserved — only their per-entry values are migrated. Delete the sources explicitly afterward if no longer needed.
+
+### Change a Field's Type
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/FieldDefinitions/{fieldId}/ChangeType
+```
+
+Converts a field to a different `newFieldType`. The conversion may reset type-specific configuration (length, constraint, format), clear list items when leaving the `List` type, and drop default or per-entry values that don't fit the target type. `allowDataLoss = true` is required for any conversion the server treats as lossy. The only conversions exempt are the safe widenings `Date → DateTime`, `ShortInteger → LongInteger`, `ShortInteger → Number`, and `LongInteger → Number` (and only when no other lossy condition applies). Changing a field to its current type is a no-op.

--- a/src/docs/guides/metadata/guide_manage-template-definitions/index.md
+++ b/src/docs/guides/metadata/guide_manage-template-definitions/index.md
@@ -1,0 +1,99 @@
+---
+layout: default
+title: Manage Template Definitions
+nav_order: 7
+parent: Repository Metadata
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Manage Template Definitions
+**Applies to**: Repository API v2 Cloud.
+
+A template definition is a named, ordered collection of [field definitions](../guide_manage-field-definitions/) that can be assigned to entries. These endpoints let repository administrators create and manage template definitions and their field membership over REST; previously the `TemplateDefinitions` surface was read-only (list and get).
+
+All template-definition endpoints are repository-scoped and rooted at:
+
+```
+v2/Repositories/{repositoryId}/TemplateDefinitions
+```
+
+Creating, updating, and deleting templates requires the `repository.Write` scope; the introspection reads require `repository.Read`.
+
+## Create a Template Definition
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/TemplateDefinitions
+```
+
+`name` is required. Optional `description`, `color`, `isAutoAssignable`, and an initial `fields` array — each entry has a required `fieldName` plus optional per-template `isRequired` and `localDescription`. Field order follows the array order.
+
+**Sample: create a template with two fields**
+
+```json
+{
+  "name": "Invoice",
+  "description": "Accounts-payable invoice template",
+  "isAutoAssignable": false,
+  "fields": [
+    { "fieldName": "Invoice Number", "isRequired": true },
+    { "fieldName": "Department", "localDescription": "Cost center to bill" }
+  ]
+}
+```
+
+The response is the created template definition, including its server-assigned `id`. Initial fields are applied to the template immediately after it is created. If a field assignment fails partway through the list, the template is created with the fields applied so far; the error is reported but not rolled back, so verify membership and retry the remaining fields if needed.
+
+## Update a Template Definition
+
+```
+PATCH https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}
+```
+
+Partial update of template properties (`name`, `description`, `color`, `isAutoAssignable`). Omit a property to leave it unchanged. For `color`, send an explicit `null` to clear the color. A name collision returns `400`.
+
+## Delete a Template Definition
+
+```
+DELETE https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/TemplateDefinitions/{templateId}
+```
+
+Returns `204 No Content` on success, or `409 Conflict` if the template is still assigned to entries. Use `GET .../TemplateDefinitions/{templateId}/AssignedEntryCount` to check usage first.
+
+## Template Field Management
+
+Fields are added, reordered, and removed individually. Adding or removing a field from a template does **not** affect field values already stored on entries that use the template.
+
+```
+POST   .../TemplateDefinitions/{templateId}/Fields
+PATCH  .../TemplateDefinitions/{templateId}/Fields/{fieldName}
+DELETE .../TemplateDefinitions/{templateId}/Fields/{fieldName}
+POST   .../TemplateDefinitions/{templateId}/Fields/Move
+```
+
+- **Add** — `POST .../Fields` with `{ fieldName, position?, isRequired?, localDescription? }`. `position` is 1-based; omit it to append.
+- **Update per-template properties** — `PATCH .../Fields/{fieldName}` with `{ isRequired?, localDescription? }`. The per-template required flag is distinct from the field definition's repository-level `isRequired` flag (see note below).
+- **Remove** — `DELETE .../Fields/{fieldName}`.
+- **Move** — `POST .../Fields/Move` with `{ fieldName, newPosition }` (1-based).
+
+> **Required, two ways.** A field can be required at the *field-definition* level (repository-wide, set when you create or update the field) and/or *per template* (set here). They coexist; the read side reports a field as required if either applies.
+
+## Reading Template Definitions
+
+The existing template read endpoints continue to work and now surface two additional properties contributed by this release:
+
+- `isAutoAssignable` on the template definition.
+- `localDescription` on each template field (per-template `isRequired` was already exposed).
+
+```
+GET .../TemplateDefinitions
+GET .../TemplateDefinitions/{templateId}
+GET .../TemplateDefinitions/{templateId}/FieldDefinitions
+GET .../TemplateDefinitions/{templateId}/AssignedEntryCount
+GET  .../TemplateDefinitions/{templateId}/Properties
+PATCH .../TemplateDefinitions/{templateId}/Properties
+```
+
+Like field definitions, templates also carry an extended key-value `Properties` bag for integration metadata that should persist with the template definition. `PATCH .../Properties` accepts `{ set: { ... }, remove: [ ... ] }`.


### PR DESCRIPTION
Adds developer guides for the Phase 2 Repository API V2 surface expansion (PRD 6.3 + REQ-DOC-002):

- **Manage Field Definitions** (`guides/metadata/guide_manage-field-definitions`) — create/update/delete field definitions, list-value management, relationships & usage, extended properties, and destructive operations (merge, change type) with the `allowDataLoss` gate.
- **Manage Template Definitions** (`guides/metadata/guide_manage-template-definitions`) — template CRUD, per-template field management (add/update/remove/move), and the new `isAutoAssignable` / `localDescription` read fields.
- **Entry Introspection** (`guides/documents-and-folders/guide_entry-introspection`) — opt-in `includeChildInfo` (folder immediate-children counts) and `includeTotalSize` (document total stored size) on Get Entry.

Applies to Repository API v2 Cloud.