### PR TITLE
Documentation: Repository API V2 access control, records management, annotations & stamps, and user areas

### DIFF
--- a/src/docs/api/repository-api-reference/index.md
+++ b/src/docs/api/repository-api-reference/index.md
@@ -26,7 +26,11 @@ Laserfiche Repository API enables programmatic access to [Cloud](https://doc.las
 - [Manipulate pages — create, replace, rotate, move, copy, and delete](../../guides/documents-and-folders/guide_page-manipulation/)
 - [Manage document locks and versions — lock / unlock, check-in / check-out](../../guides/documents-and-folders/guide_document-lifecycle/)
 - [Read/Write entry metadata](../../guides/metadata/)
+- [Read and write annotations, and manage stamps](../../guides/documents-and-folders/guide_annotations-and-stamps/)
 - [Search the Repository](../../guides/search/)
+- [Manage access control and rights — entries, fields, templates, trustees](../../guides/access-control/)
+- [Manage records — properties, retention events, and record series](../../guides/records-management/)
+- [Manage user areas — Recent, Starred, and Personal Collections](../../guides/user-areas/)
 
 ## Try it out
 

--- a/src/docs/guides/access-control/guide_access-control/index.md
+++ b/src/docs/guides/access-control/guide_access-control/index.md
@@ -1,0 +1,97 @@
+---
+layout: default
+title: Manage Access Control and Rights
+nav_order: 1
+parent: Access Control
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Manage Access Control and Rights
+**Applies to**: Repository API v2 Cloud.
+
+Applications can read and manage access rights across the repository's securable scopes — **entries**, **field definitions**, and **template definitions** — plus query the current session's rights, look up trustees, and read a trustee's repository security. All of these operations share a single **AccessControl** API group (one `AccessControlClient` in the client libraries); the routes stay nested under the resource they secure.
+
+Read operations require the `repository.Read` scope; writes require `repository.Write`. Beyond the OAuth scope, the LFS session enforces the underlying permission — a caller lacking the right to view or change security receives a `403`.
+
+## Two ways to look at rights
+
+There are two distinct questions you can ask about a securable object:
+
+1. **What is its access control list (ACL)?** — the explicit (and inherited) access control entries that grant or deny rights to trustees. This is what you edit.
+2. **What rights does a given trustee actually have on it?** — the *net effective* rights after inheritance, group membership, allow/deny resolution, and the privilege / records-management overlays.
+
+The `AccessControl` sub-resource answers (1); the `Rights` sub-resource answers (2).
+
+### The Rights query
+
+A single `Rights` endpoint per securable object replaces the originally separate effective/direct routes. It takes an `aclOnly` flag:
+
+- `aclOnly=false` (default) — the net **effective** rights, after inheritance, group membership, allow/deny resolution, and the privilege / records-management overlays.
+- `aclOnly=true` — only the rights granted by the object's **own ACL**, without the privilege/RM overlay (group membership is still resolved).
+
+Both modes also return `isReadOnly`. Target a specific trustee with `?trusteeId={sid}` or `?trusteeName={name}`; omit both to resolve to the calling session.
+
+## Entry access rights
+
+```
+GET  https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/AccessControl[?includeInherited=]
+PUT  .../Entries/{entryId}/AccessControl
+GET  .../Entries/{entryId}/Rights[?trusteeId=|?trusteeName=][&aclOnly=]
+```
+
+**`GET .../AccessControl`** returns the entry's access control list: the access control entries — each with a `trustee`, an `accessControlType` (`Allow` / `Deny`), the granted or denied `rights`, and a propagation `scope` — plus whether the entry inherits rights from its parent(s).
+
+- `includeInherited=true` (default) returns both explicit and inherited ACEs; inherited entries carry `isInherited = true`.
+- `includeInherited=false` returns only the explicit ACEs — the exact set that the `PUT` accepts.
+
+**`PUT .../AccessControl`** fully replaces the entry's explicit access control entries. An empty array clears them; inherited entries cannot be supplied. Each entry is keyed by `trustee.sid`. The `inheritParents` flag controls whether the entry inherits from its parents — omit it to preserve the current setting. Returns the updated ACL.
+
+**`GET .../Rights`** is the rights query described [above](#the-rights-query).
+
+## Field and template access rights
+
+Field definitions and template definitions are secured the same way, plus a repository-wide **default** ACL applied to newly created definitions:
+
+```
+GET / PUT .../FieldDefinitions/{fieldId}/AccessControl
+GET       .../FieldDefinitions/{fieldId}/Rights[?trusteeId=|?trusteeName=][&aclOnly=]
+GET / PUT .../FieldDefinitions/DefaultAccessControl
+
+GET / PUT .../TemplateDefinitions/{templateId}/AccessControl
+GET       .../TemplateDefinitions/{templateId}/Rights[?trusteeId=|?trusteeName=][&aclOnly=]
+GET / PUT .../TemplateDefinitions/DefaultAccessControl
+```
+
+- `AccessControl` (GET/PUT) reads and full-replaces a definition's ACL — same shape as the entry ACL.
+- `Rights` (GET) is the rights query for that definition.
+- `DefaultAccessControl` (GET/PUT) reads and replaces the default ACL applied to newly created field / template definitions.
+
+## Session rights
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/SessionRights
+```
+
+Returns the current session's privileges and feature rights (named-boolean maps) plus `isReadOnly` — useful for UI enablement and pre-flight checks. This reflects the **current session only**.
+
+## Trustee lookup
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Trustees?search={name}&type={user|group}&count={n}
+```
+
+Searches users and groups by name. Each match returns its SID, account name, display name, type, whether it is a user or a group, and whether it is disabled. Use this to resolve names to the SIDs you supply when building access control entries or addressing a trustee in a `Rights` query.
+
+## Trustee security
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Trustees/{trusteeId}/Security[?includeInherited=]
+```
+
+Returns a trustee's repository-level privileges, feature rights, security tags, and success/failure audit masks (named-boolean maps) plus `isReadOnly`.
+
+- `includeInherited=true` (default) returns the **effective** security — what applies once the trustee's group memberships are resolved. This is a documented best-effort computation; the authoritative reading is to sign in as that trustee.
+- `includeInherited=false` returns the **direct** security assigned on the trustee record itself, without group-membership inheritance.

--- a/src/docs/guides/access-control/guide_access-control/index.md
+++ b/src/docs/guides/access-control/guide_access-control/index.md
@@ -27,7 +27,7 @@ The `AccessControl` sub-resource answers (1); the `Rights` sub-resource answers 
 
 ### The Rights query
 
-A single `Rights` endpoint per securable object replaces the originally separate effective/direct routes. It takes an `aclOnly` flag:
+A single `Rights` endpoint per securable object answers this question, controlled by an `aclOnly` flag:
 
 - `aclOnly=false` (default) — the net **effective** rights, after inheritance, group membership, allow/deny resolution, and the privilege / records-management overlays.
 - `aclOnly=true` — only the rights granted by the object's **own ACL**, without the privilege/RM overlay (group membership is still resolved).
@@ -47,7 +47,7 @@ GET  .../Entries/{entryId}/Rights[?trusteeId=|?trusteeName=][&aclOnly=]
 - `includeInherited=true` (default) returns both explicit and inherited ACEs; inherited entries carry `isInherited = true`.
 - `includeInherited=false` returns only the explicit ACEs — the exact set that the `PUT` accepts.
 
-**`PUT .../AccessControl`** fully replaces the entry's explicit access control entries. An empty array clears them; inherited entries cannot be supplied. Each entry is keyed by `trustee.sid`. The `inheritParents` flag controls whether the entry inherits from its parents — omit it to preserve the current setting. Returns the updated ACL.
+**`PUT .../AccessControl`** fully replaces the entry's explicit access control entries (ACEs). An empty array clears them; inherited ACEs cannot be supplied. Each ACE is keyed by its `trustee.sid`. The `inheritParents` flag controls whether the entry inherits rights from its parents — omit it to preserve the current setting. Returns the updated ACL.
 
 **`GET .../Rights`** is the rights query described [above](#the-rights-query).
 
@@ -76,6 +76,8 @@ GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Session
 ```
 
 Returns the current session's privileges and feature rights (named-boolean maps) plus `isReadOnly` — useful for UI enablement and pre-flight checks. This reflects the **current session only**.
+
+This is distinct from the per-object `Rights` query above: `SessionRights` reports repository-wide privileges and feature rights held by the calling session, not the rights a trustee has on a specific securable object. It is scoped to the caller's own session and does not accept a trustee parameter.
 
 ## Trustee lookup
 

--- a/src/docs/guides/access-control/index.md
+++ b/src/docs/guides/access-control/index.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Access Control
+nav_order: 4
+has_children: true
+parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Access Control
+
+These guides show how to read and manage the access rights that secure your repository — the access control lists on entries, fields, and templates, the effective rights a trustee has, the current session's rights, and trustee lookup and security.

--- a/src/docs/guides/documents-and-folders/guide_annotations-and-stamps/index.md
+++ b/src/docs/guides/documents-and-folders/guide_annotations-and-stamps/index.md
@@ -1,0 +1,179 @@
+---
+layout: default
+title: Annotations and Stamps
+nav_order: 9
+parent: Repository Folders and Documents
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Annotations and Stamps
+**Applies to**: Repository API v2 Cloud.
+
+Annotations are markups placed on the image pages of a document — highlights, redactions, notes, stamps, and more. This guide covers reading and writing annotations, administering the repository's redaction reasons, and managing the repository's stamp catalog.
+
+Annotations are attached to a document's **image pages** (see the [Manipulate Document Pages guide](../guide_page-manipulation/) for how pages are structured). Each annotation carries a common header plus type-specific properties, and is identified within its page by an `itemId`.
+
+Annotation endpoints are rooted under an entry and, for most operations, a page:
+
+```
+v2/Repositories/{repositoryId}/Entries/{entryId}/Annotations
+v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations
+```
+
+Reading annotations requires the `repository.Read` scope; creating, updating, and deleting them requires `repository.Write`. Beyond the OAuth scope, the LFS session enforces the underlying entry rights — reading requires the "see annotations" right (and redaction content additionally requires "see through redactions"); writing requires the "annotate" right.
+
+## The annotation shape
+
+Annotations are returned (and created) as a **polymorphic** object discriminated by `annotationType`. Every annotation shares a common header:
+
+| Member | Notes |
+|---|---|
+| `annotationType` | One of the 14 types below. Determines the type-specific members. |
+| `itemId` | Identifier of the annotation within its page. |
+| `pageNumber` | The page the annotation is on. |
+| `creator` | Trustee that created the annotation. |
+| `createdTime`, `lastModifiedTime` | Timestamps. |
+| `comment` | Free-text comment. |
+| `visibility` | Who can see the annotation. |
+| `isProtected` | Whether the annotation is protected from edits by other users. |
+| `zOrder` | Stacking order on the page. |
+| `reasonId` | For redactions — the redaction reason (see [Redaction Reasons](#redaction-reasons)). |
+| `accessType` | The caller's access to this annotation. |
+
+Type-specific members follow the header. Geometry is expressed in **image pixels** as `{ x, y, width, height }`; colors are `#RRGGBB` strings and are `null` when transparent.
+
+The 14 annotation types are: `highlight`, `redaction`, `strikeout`, `underline`, `note`, `attachment`, `textBox`, `bitmap`, `line`, `rectangle`, `polyline`, `callout`, `stamp`, and `freehand`.
+
+## Read Annotations
+
+List every annotation on a document:
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Annotations
+```
+
+List the annotations on a single page:
+
+```
+GET .../Entries/{entryId}/Pages/{pageNumber}/Annotations
+```
+
+Get a single annotation:
+
+```
+GET .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}
+```
+
+All three return the polymorphic shape described above (a list for the first two, a single object for the last).
+
+### Attachment content
+
+An `attachment` annotation carries a file. Stream its content with:
+
+```
+GET .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Attachment
+```
+
+## Write Annotations
+
+### Create
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/Pages/{pageNumber}/Annotations
+```
+
+The request body is the same polymorphic shape as the read response, discriminated by `annotationType`. Supply the header members you want to set plus the type-specific geometry and properties. The response is the created annotation, including its server-assigned `itemId`.
+
+Operations are atomic — the server acquires and releases the page lock within the single request; you do not manage locks yourself.
+
+**Sample: create a highlight**
+
+```json
+{
+  "annotationType": "highlight",
+  "position": { "x": 100, "y": 200, "width": 300, "height": 40 },
+  "color": "#FFFF00",
+  "comment": "Follow up on this clause"
+}
+```
+
+### Update
+
+```
+PATCH .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}
+```
+
+A partial patch — members omitted from the body are left unchanged. The body's `annotationType` must match the existing annotation's type.
+
+### Delete
+
+```
+DELETE .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}
+```
+
+### Attachment and bitmap content
+
+Two annotation types hold binary content that is uploaded separately after the annotation is created:
+
+```
+PUT .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Attachment
+PUT .../Entries/{entryId}/Pages/{pageNumber}/Annotations/{itemId}/Image
+```
+
+- `Attachment` uploads the content (`multipart/form-data`) of an `attachment` annotation. Create the attachment annotation first, then upload its bytes here.
+- `Image` uploads the image (`multipart/form-data`) of a `bitmap` annotation.
+
+## Redaction Reasons
+
+Redaction annotations can reference a repository-defined reason (via the annotation's `reasonId`). The repository's reasons are listed and administered under the repository root:
+
+```
+GET  https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/AnnotationReasons
+POST .../AnnotationReasons
+PATCH .../AnnotationReasons/{reasonId}
+DELETE .../AnnotationReasons/{reasonId}
+```
+
+- `GET` lists the repository's redaction reasons.
+- `POST` creates a reason.
+- `PATCH` updates a reason's text.
+- `DELETE` removes a reason. Pass `force=true` to delete a reason that is currently in use.
+
+## Manage Stamps
+
+A stamp annotation references an entry in the repository's **stamp catalog**. The catalog holds public stamps (shared repository-wide) and each user's personal stamps. Catalog metadata is returned without the image bytes; a stamp's image is fetched and uploaded separately as a PNG.
+
+Stamp endpoints are rooted at the repository:
+
+```
+v2/Repositories/{repositoryId}/Stamps
+```
+
+Managing a **public** stamp requires the stamp-management privilege; personal stamps require no special privilege.
+
+### List and read
+
+```
+GET .../Stamps?scope=public|personal|all
+GET .../Stamps/{stampId}
+GET .../Stamps/{stampId}/Image
+```
+
+- List stamps, filtered by `scope` (`public`, `personal`, or `all`).
+- Get a single stamp's metadata.
+- Download a stamp's image as a PNG. An optional `color=#RRGGBB` query parameter recolors the image. Only public/common stamps are served here; requesting a personal stamp's image returns `404`.
+
+### Create, update, delete
+
+```
+POST .../Stamps
+PATCH .../Stamps/{stampId}
+DELETE .../Stamps/{stampId}
+```
+
+- `POST` creates a stamp from an uploaded image. The image is sent as the `multipart/form-data` `file` part; `name` and `isPublic` are query parameters. The service converts the image to the repository's internal format.
+- `PATCH` updates a stamp's `name` and/or custom data. **The image is immutable after creation** — to change the image, create a new stamp.
+- `DELETE` removes a stamp.

--- a/src/docs/guides/records-management/guide_records-management/index.md
+++ b/src/docs/guides/records-management/guide_records-management/index.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Manage Records
+nav_order: 1
+parent: Records Management
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Manage Records
+**Applies to**: Repository API v2 Cloud.
+
+Applications can read and manage the records management state of entries over REST — record and record-folder properties, retention events, record eligibility, and record series.
+
+Records management endpoints are nested under an entry:
+
+```
+v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement
+v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries
+```
+
+Read operations require the `repository.Read` scope; writes require `repository.Write`. In addition, the repository's **Records Management feature** must be enabled and the applicable records management privilege / entry rights are enforced by the server. Computed members are read-only and are marked as such in the schema.
+
+## Records management properties
+
+```
+GET   https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/Properties
+PATCH .../Entries/{entryId}/RecordsManagement/Properties
+```
+
+**`GET`** returns the records management properties of a record or record folder as a single shape discriminated by `recordType` (`record` | `recordFolder`); members that do not apply to the entry's type are omitted. If the entry is neither a record nor a record folder, the endpoint returns `404`.
+
+**`PATCH`** updates the writable subset:
+
+- `null` leaves a member unchanged.
+- Id members accept `0` to clear.
+- The record-folder `triggerDate` and the record `lastReviewDate` are cleared via their `clear*` flags.
+
+Applying `PATCH` to a **plain document** promotes it to a record, and to a **plain folder** promotes it to a record folder, before the properties are applied. Members not applicable to the resulting type are rejected with `400`.
+
+## Retention events
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/SetEvent
+POST .../Entries/{entryId}/RecordsManagement/RemoveEvent
+```
+
+Set or remove a records management event date on a record or record folder.
+
+## Record eligibility and independent records
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordsManagement/EligibleRecords?eligibleFor=disposition|transfer
+GET .../Entries/{entryId}/RecordsManagement/IndependentRecords
+GET .../Entries/{entryId}/RecordsManagement/AltRetentionEvents
+```
+
+- `EligibleRecords` returns the ids of the records under a record folder that are eligible for the requested action (`disposition` or `transfer`).
+- `IndependentRecords` returns the ids of the independent records under a record folder.
+- `AltRetentionEvents` returns a record folder's alternate-retention trigger events.
+
+## Record series
+
+```
+GET   https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/Entries/{entryId}/RecordSeries/Properties
+PATCH .../Entries/{entryId}/RecordSeries/Properties
+POST  .../Entries/{parentEntryId}/RecordSeries
+```
+
+- `GET / PATCH .../RecordSeries/Properties` reads and updates a record series' cascading retention defaults. The update's `cascade` flag applies the change to the file plan beneath the series.
+- `POST .../Entries/{parentEntryId}/RecordSeries` creates a record series under a parent folder (`name`, `code`).
+
+To delete a record series, use the standard [Delete Entry](../../documents-and-folders/) endpoint.

--- a/src/docs/guides/records-management/index.md
+++ b/src/docs/guides/records-management/index.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: Records Management
+nav_order: 5
+has_children: true
+parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Records Management
+
+These guides show how to read and manage the records management state of entries over the Laserfiche API — record and record-folder properties, retention events, record eligibility, and record series.

--- a/src/docs/guides/user-areas/guide_user-areas/index.md
+++ b/src/docs/guides/user-areas/guide_user-areas/index.md
@@ -1,0 +1,86 @@
+---
+layout: default
+title: Recent, Starred, Collections, and User Areas
+nav_order: 1
+parent: User Areas
+grand_parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# Recent, Starred, Collections, and User Areas
+**Applies to**: Repository API v2 Cloud.
+
+User areas are per-user, owner-scoped named sets of entries — the favorites and working sets that the Laserfiche apps maintain for each user. This guide covers the three application-managed concepts (Recent, Starred, Personal Collections) and the generic user-area primitive.
+
+All endpoints are repository-scoped and operate on the **authenticated user's own** areas. Reads require the `repository.Read` scope; writes require `repository.Write`.
+
+## Recent Documents and Folders
+
+The per-user Recent Documents and Recent Folders lists maintained by the Laserfiche apps are read-only over REST. Both endpoints return entries most-recently-accessed first; if the user has no recents, an empty collection is returned.
+
+```
+GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/RecentDocuments[?documentLimit=]
+GET .../RecentFolders
+```
+
+- `RecentDocuments` returns the user's recently accessed documents (`entryId`, `fullPath`). The optional `documentLimit` query parameter caps the number of results — `0` returns an empty list; negative values are rejected.
+- `RecentFolders` returns the user's recently accessed folders (`entryId`, `fullPath`).
+
+## Starred entries
+
+The per-user Starred list is readable and writable.
+
+```
+GET    https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/StarredEntries
+POST   .../StarredEntries
+DELETE .../StarredEntries
+```
+
+- `GET` returns the user's starred entries (`entryId`, `fullPath`).
+- `POST` stars one or more entries (`entryIds`); idempotent for already-starred entries. The user's Starred area is created on first use. Returns the updated list.
+- `DELETE` unstars one or more entries (`entryIds`); idempotent. Returns the updated list.
+
+## Personal Collections
+
+Personal Collections are per-user named sets of entries with full CRUD. Each collection has a stable `id`, a display `name`, and member `entryIds`. Names must be unique (case-insensitive), 256 characters or fewer, and must not use a reserved name (`Starred`, `Recent Documents`); a user may have at most 50 collections.
+
+```
+GET    https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/PersonalCollections
+POST   .../PersonalCollections
+GET    .../PersonalCollections/{collectionId}
+PATCH  .../PersonalCollections/{collectionId}
+DELETE .../PersonalCollections/{collectionId}
+POST   .../PersonalCollections/{collectionId}/Entries
+DELETE .../PersonalCollections/{collectionId}/Entries
+```
+
+- `GET .../PersonalCollections` lists the user's collections.
+- `POST .../PersonalCollections` creates a collection (`name`). Returns `409` on a duplicate or reserved name; `400` on a too-long name or when the 50-collection limit is reached.
+- `GET .../PersonalCollections/{collectionId}` gets a single collection.
+- `PATCH .../PersonalCollections/{collectionId}` renames a collection (`name`).
+- `DELETE .../PersonalCollections/{collectionId}` deletes a collection (idempotent; `204`).
+- `POST` / `DELETE .../PersonalCollections/{collectionId}/Entries` adds or removes member entries (`entryIds`); returns the updated collection.
+
+## Generic user areas
+
+The raw user-area primitive is exposed for the caller's own areas. Application-managed areas (Personal Collections, Starred, Recent) are hidden from this surface, so a raw write cannot corrupt the app conventions.
+
+```
+GET    https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/UserAreas
+POST   .../UserAreas
+GET    .../UserAreas/{areaId}
+PUT    .../UserAreas/{areaId}
+DELETE .../UserAreas/{areaId}
+GET    .../UserAreas/{areaId}/Entries
+POST   .../UserAreas/{areaId}/Entries
+DELETE .../UserAreas/{areaId}/Entries
+```
+
+- `GET .../UserAreas` lists the caller's user areas (`id`, `name`, `comment`, `data`).
+- `POST .../UserAreas` creates a user area (`name`, optional `comment` / `data`). Reserved names are rejected.
+- `GET .../UserAreas/{areaId}` gets a user area.
+- `PUT .../UserAreas/{areaId}` is a partial update (`name` / `comment` / `data`; `null` leaves a member unchanged).
+- `DELETE .../UserAreas/{areaId}` deletes a user area (`204`).
+- `GET` / `POST` / `DELETE .../UserAreas/{areaId}/Entries` lists, adds, or removes member entries (`entryIds`).

--- a/src/docs/guides/user-areas/guide_user-areas/index.md
+++ b/src/docs/guides/user-areas/guide_user-areas/index.md
@@ -25,8 +25,10 @@ GET https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/RecentD
 GET .../RecentFolders
 ```
 
-- `RecentDocuments` returns the user's recently accessed documents (`entryId`, `fullPath`). The optional `documentLimit` query parameter caps the number of results — `0` returns an empty list; negative values are rejected.
-- `RecentFolders` returns the user's recently accessed folders (`entryId`, `fullPath`).
+- `RecentDocuments` (read-only) returns the user's recently accessed documents (`entryId`, `fullPath`). The optional `documentLimit` query parameter caps the number of results — `0` returns an empty list; negative values are rejected.
+- `RecentFolders` (read-only) returns the user's recently accessed folders (`entryId`, `fullPath`).
+
+The Laserfiche apps maintain these lists; there is no write operation for them over REST.
 
 ## Starred entries
 
@@ -65,7 +67,9 @@ DELETE .../PersonalCollections/{collectionId}/Entries
 
 ## Generic user areas
 
-The raw user-area primitive is exposed for the caller's own areas. Application-managed areas (Personal Collections, Starred, Recent) are hidden from this surface, so a raw write cannot corrupt the app conventions.
+The raw user-area primitive is exposed for the caller's own areas. Application-managed areas (Personal Collections, Starred, Recent) are hidden from this surface so a raw write cannot corrupt the app conventions — they remain fully readable and writable through their own dedicated endpoints above.
+
+A Personal Collection is itself a user area that follows an application convention (a reserved naming scheme plus a structured `data` payload that the Laserfiche apps recognize). The `PersonalCollections` endpoints manage that convention for you, so you never construct it by hand — which is why they are kept separate from these generic endpoints. Use `PersonalCollections`, `StarredEntries`, or the Recent endpoints to work with those app-managed areas; use `UserAreas` for your own arbitrary areas.
 
 ```
 GET    https://api.laserfiche.com/repository/v2/Repositories/{repositoryId}/UserAreas
@@ -84,3 +88,42 @@ DELETE .../UserAreas/{areaId}/Entries
 - `PUT .../UserAreas/{areaId}` is a partial update (`name` / `comment` / `data`; `null` leaves a member unchanged).
 - `DELETE .../UserAreas/{areaId}` deletes a user area (`204`).
 - `GET` / `POST` / `DELETE .../UserAreas/{areaId}/Entries` lists, adds, or removes member entries (`entryIds`).
+
+### Example: create a user area and add entries
+
+Create a working set named "Q3 Review". `comment` and `data` are optional; `data` is an opaque string your integration controls (for example, a serialized JSON blob).
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/r-abcd1234/UserAreas
+```
+```json
+{
+  "name": "Q3 Review",
+  "comment": "Documents to review this quarter",
+  "data": "{\"color\":\"blue\"}"
+}
+```
+
+The response returns the created area with its server-assigned `id`:
+
+```json
+{
+  "id": 5012,
+  "name": "Q3 Review",
+  "comment": "Documents to review this quarter",
+  "data": "{\"color\":\"blue\"}"
+}
+```
+
+Add entries to the area by its `id`:
+
+```
+POST https://api.laserfiche.com/repository/v2/Repositories/r-abcd1234/UserAreas/5012/Entries
+```
+```json
+{
+  "entryIds": [908, 2162601]
+}
+```
+
+The response returns the area's updated members (`entryId`, `fullPath`).

--- a/src/docs/guides/user-areas/index.md
+++ b/src/docs/guides/user-areas/index.md
@@ -1,0 +1,14 @@
+---
+layout: default
+title: User Areas
+nav_order: 6
+has_children: true
+parent: Guides
+---
+
+<!--© 2026 Laserfiche.
+See LICENSE-DOCUMENTATION and LICENSE-CODE in the project root for license information.-->
+
+# User Areas
+
+These guides show how to read and manage the per-user areas that the Laserfiche apps maintain — Recent Documents and Folders, Starred entries, and Personal Collections — plus the generic user-area primitive that backs them.


### PR DESCRIPTION
Phase 3 developer.laserfiche.com guides for the V2 REST API surface shipped under WI #680169.

## New guides
- **Access Control** (new category) — entry / field / template ACLs (`AccessControl` GET/PUT), the unified `Rights` query (`aclOnly`, `trusteeId`/`trusteeName`), default field/template ACLs, session rights, trustee lookup, and trustee security.
- **Records Management** (new category) — RM properties (GET/PATCH, `recordType` discriminator, promotion on PATCH), retention events (Set/RemoveEvent), eligible/independent records, alternate retention events, and record series.
- **User Areas** (new category) — Recent Documents/Folders, Starred, Personal Collections (CRUD + members), and the generic user-area primitive.
- **Annotations and Stamps** (under Documents and Folders) — annotation read/write across the 14 types, attachment/bitmap content upload, redaction reasons, and the stamp catalog.

## Other
- Repository API reference overview updated with capability links to the new guides.

All documented endpoints are GA on Cloud. Sourced from the server V2 changelog (2026-06). Navigation uses the existing just-the-docs parent/grand_parent pattern; internal links validated.